### PR TITLE
Bash refactor to style guide

### DIFF
--- a/.run/Run dsu.run.xml
+++ b/.run/Run dsu.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run dsu" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package dsu --bin dsu" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs>
+      <env name="PKG_CONFIG_PATH" value="/nix/store/8pvlw63anasimxk2q17c85aabvv5kl8l-openssl-3.0.14-dev/lib/pkgconfig" />
+    </envs>
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="STABLE" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Test dsu.run.xml
+++ b/.run/Test dsu.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test dsu" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --workspace" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="STABLE" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/build.sh
+++ b/build.sh
@@ -1,75 +1,83 @@
 #!/usr/bin/env bash
 #
+# Package the scripts in the sh directory into a tarball.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 usage() {
-    cat <<EOF
-Usage: $(basename "$0")
+	local app=${0##*/}
+	cat <<EOF
+Usage: $app
 Creates a tarball of the scripts in the sh directory and save it to the dist directory.
 
 Example:
-    $(basename "$0") - Will create a tarball of the scripts in the sh directory.
+    $app - Will create a tarball of the scripts in the sh directory.
 EOF
 }
 
 make_tarball() {
-    local root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local src_dir="$root_dir/sh"
-    local dist_dir="$root_dir/dist"
-    local bin_dir="$dist_dir/bin"
-    local version="$(cat "$root_dir/VERSION")"
-    local tarball_name="dsu-$version.tar.gz"
+	local root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local src_dir="$root_dir/sh"
+	local dist_dir="$root_dir/dist"
+	local bin_dir="$dist_dir/bin"
+	local version="$(cat "$root_dir/VERSION")"
+	local tarball_name="dsu-$version.tar.gz"
 
-    # Check if source directory exists
-    if [ ! -d "$src_dir" ]; then
-        echo "Error: Source directory '$src_dir' not found" >&2
-        exit 1
-    fi
+	# Check if source directory exists
+	if [ ! -d "$src_dir" ]; then
+		echo "Error: Source directory '$src_dir' not found" >&2
+		exit 1
+	fi
 
-    # Recreate dist directory
-    rm -rf "$dist_dir"
-    mkdir -p "$bin_dir"
+	# Recreate dist directory
+	rm -rf "$dist_dir"
+	mkdir -p "$bin_dir"
 
-    # Copy the scripts to the dist directory
-    for file in "$src_dir"/*; do
-        cp "$file" "$bin_dir"
+	# Copy the scripts to the dist directory
+	for file in "$src_dir"/*; do
+		cp "$file" "$bin_dir"
 
-        local filepath="$bin_dir/$(basename "$file")"
-        chmod +x "$filepath"
+		local filepath="$bin_dir/$(basename "$file")"
+		chmod +x "$filepath"
 
-        # Remove extension from the file
-        local filename="${filepath%.*}"
-        mv "$filepath" "$filename"
-    done
+		# Remove extension from the file
+		local filename="${filepath%.*}"
+		mv "$filepath" "$filename"
+	done
 
-    # Create a tarball of bin directory
-    tar -czf "$dist_dir/$tarball_name" -C "$dist_dir" bin
+	# Create a tarball of bin directory
+	tar -czf "$dist_dir/$tarball_name" -C "$dist_dir" bin
 
-    # Remove bin directory
-    rm -rf "$bin_dir"
+	# Remove bin directory
+	rm -rf "$bin_dir"
 
-    echo "Tarball created: $dist_dir/$tarball_name"
+	echo "Tarball created: $dist_dir/$tarball_name"
 }
 
 main() {
-    # Parse arguments
-    while [[ "$#" -gt 0 ]]; do
-        case "$1" in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        *)
-            echo "Error: Unknown option: $1" >&2
-            usage
-            exit 1
-            ;;
-        esac
-    done
+	# Parse arguments
+	while [[ "$#" -gt 0 ]]; do
+		case "$1" in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			*)
+				echo "Error: Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+		esac
+	done
 
-    make_tarball
+	make_tarball
 }
 
 main "$@"

--- a/build.sh
+++ b/build.sh
@@ -23,12 +23,18 @@ EOF
 }
 
 make_tarball() {
-	local root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local root_dir version filepath
 	local src_dir="$root_dir/sh"
 	local dist_dir="$root_dir/dist"
 	local bin_dir="$dist_dir/bin"
-	local version="$(cat "$root_dir/VERSION")"
 	local tarball_name="dsu-$version.tar.gz"
+
+	root_dir=${BASH_SOURCE[0]%/*}
+	if [[ -z "$root_dir" ]] || [[ "$root_dir" == "${BASH_SOURCE[0]}" ]]; then
+		root_dir="."
+	fi
+
+	version="$(cat "$root_dir/VERSION")"
 
 	# Check if source directory exists
 	if [[ ! -d "$src_dir" ]]; then
@@ -44,7 +50,7 @@ make_tarball() {
 	for file in "$src_dir"/*; do
 		cp "$file" "$bin_dir"
 
-		local filepath="$bin_dir/$(basename "$file")"
+		filepath="$bin_dir/${file##*/}"
 		chmod +x "$filepath"
 
 		# Remove extension from the file
@@ -63,7 +69,7 @@ make_tarball() {
 
 main() {
 	# Parse arguments
-	while [[ "$#" -gt 0 ]]; do
+	while (($# > 0)); do
 		case "$1" in
 			-h | --help)
 				usage

--- a/build.sh
+++ b/build.sh
@@ -15,10 +15,11 @@ usage() {
 	local app=${0##*/}
 	cat <<EOF
 Usage: $app
+
 Creates a tarball of the scripts in the sh directory and save it to the dist directory.
 
-Example:
-    $app - Will create a tarball of the scripts in the sh directory.
+Example
+	$app - Will create a tarball of the scripts in the sh directory.
 EOF
 }
 

--- a/build.sh
+++ b/build.sh
@@ -24,13 +24,13 @@ EOF
 
 make_tarball() {
 	local version filepath filename tarball_name
-	local version_file="./VERSION"
+	local version_file="./version"
 	local src_dir="./sh"
 	local dist_dir="./dist"
 	local bin_dir="$dist_dir/bin"
 
 	if [[ ! -f "$version_file" ]]; then
-		echo "Error: VERSION file not found" >&2
+		echo "Error: version file not found" >&2
 		echo "Are you in the correct directory?" >&2
 		exit 1
 	fi

--- a/build.sh
+++ b/build.sh
@@ -23,22 +23,25 @@ EOF
 }
 
 make_tarball() {
-	local root_dir version filepath
-	local src_dir="$root_dir/sh"
-	local dist_dir="$root_dir/dist"
+	local version filepath filename tarball_name
+	local version_file="./VERSION"
+	local src_dir="./sh"
+	local dist_dir="./dist"
 	local bin_dir="$dist_dir/bin"
-	local tarball_name="dsu-$version.tar.gz"
 
-	root_dir=${BASH_SOURCE[0]%/*}
-	if [[ -z "$root_dir" ]] || [[ "$root_dir" == "${BASH_SOURCE[0]}" ]]; then
-		root_dir="."
+	if [[ ! -f "$version_file" ]]; then
+		echo "Error: VERSION file not found" >&2
+		echo "Are you in the correct directory?" >&2
+		exit 1
 	fi
 
-	version="$(cat "$root_dir/VERSION")"
+	version=$(<"$version_file")
+	tarball_name="dsu-$version.tar.gz"
 
 	# Check if source directory exists
 	if [[ ! -d "$src_dir" ]]; then
 		echo "Error: Source directory '$src_dir' not found" >&2
+		echo "Are you in the correct directory?" >&2
 		exit 1
 	fi
 
@@ -54,7 +57,7 @@ make_tarball() {
 		chmod +x "$filepath"
 
 		# Remove extension from the file
-		local filename="${filepath%.*}"
+		filename="${filepath%.*}"
 		mv "$filepath" "$filename"
 	done
 

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ make_tarball() {
 	local tarball_name="dsu-$version.tar.gz"
 
 	# Check if source directory exists
-	if [ ! -d "$src_dir" ]; then
+	if [[ ! -d "$src_dir" ]]; then
 		echo "Error: Source directory '$src_dir' not found" >&2
 		exit 1
 	fi

--- a/install.sh
+++ b/install.sh
@@ -73,22 +73,22 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [[ "$LOG" -ge $LOG_QUIET ]]; then
+			if ((LOG >= LOG_QUIET)); then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
+			if ((LOG >= LOG_NORMAL)); then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
+			if ((LOG >= LOG_VERBOSE)); then
 				echo "$message"
 			fi
 			;;
 		*)
-			echo "[ERROR] Invalid log level: $level" >&2
+			log $LOG_QUIET "[ERROR] Invalid log level: $level" >&2
 			exit 1
 			;;
 	esac
@@ -97,7 +97,7 @@ log() {
 arg_parse() {
 	# Expand combined short options (e.g., -qy to -q -y)
 	expanded_args=()
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
 		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
 			expanded_args+=("$1")
@@ -119,7 +119,7 @@ arg_parse() {
 	set -- "${expanded_args[@]}"
 
 	# Parse long arguments
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case "$1" in
 			-h | --help)
 				usage
@@ -224,7 +224,7 @@ path_needs_sudo() {
 			fi
 		else
 			# if doesn't exist, set path to parent directory and check again
-			path=$(dirname "$path")
+			path=${path%/*}
 			continue
 		fi
 	done

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@
 #
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 # Log levels
 #LOG_SILENT=0
@@ -29,8 +29,8 @@ INSTALL_DIR=""
 
 CONFIG_BINARIES=()
 declare -A CONFIG=(
-  ["type"]=""
-  ["path"]=""
+	["type"]=""
+	["path"]=""
 )
 
 DRY="n"
@@ -40,8 +40,8 @@ USER_PATH=""
 SUDO_COMMAND=""
 
 usage() {
-  local name=${0##*/}
-  cat <<EOF
+	local name=${0##*/}
+	cat <<EOF
 Usage: $name [OPTIONS]
 Installs Diomeh's Script Utilities (dsu) on your system.
 
@@ -65,575 +65,575 @@ EOF
 }
 
 log() {
-  local level="$1"
-  local message="$2"
+	local level="$1"
+	local message="$2"
 
-  case "$level" in
-    0)
-      # Silent mode. No output
-      ;;
-    1)
-      if [[ "$LOG" -ge $LOG_QUIET ]]; then
-        echo "$message"
-      fi
-      ;;
-    2)
-      if [[ "$LOG" -ge $LOG_NORMAL ]]; then
-        echo "$message"
-      fi
-      ;;
-    3)
-      if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
-        echo "$message"
-      fi
-      ;;
-    *)
-      echo "[ERROR] Invalid log level: $level" >&2
-      exit 1
-      ;;
-  esac
+	case "$level" in
+		0)
+			# Silent mode. No output
+			;;
+		1)
+			if [[ "$LOG" -ge $LOG_QUIET ]]; then
+				echo "$message"
+			fi
+			;;
+		2)
+			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
+				echo "$message"
+			fi
+			;;
+		3)
+			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
+				echo "$message"
+			fi
+			;;
+		*)
+			echo "[ERROR] Invalid log level: $level" >&2
+			exit 1
+			;;
+	esac
 }
 
 arg_parse() {
-  # Expand combined short options (e.g., -qy to -q -y)
-  expanded_args=()
-  while [[ $# -gt 0 ]]; do
-    # If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
-    if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
-      expanded_args+=("$1")
-      shift
-      continue
-    fi
+	# Expand combined short options (e.g., -qy to -q -y)
+	expanded_args=()
+	while [[ $# -gt 0 ]]; do
+		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
+		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
+			expanded_args+=("$1")
+			shift
+			continue
+		fi
 
-    # Iterate over all combined short options
-    # and expand them into separate arguments
-    # eg. -qy becomes -q -y
-    for ((i = 1; i < ${#1}; i++)); do
-      expanded_args+=("-${1:i:1}")
-    done
+		# Iterate over all combined short options
+		# and expand them into separate arguments
+		# eg. -qy becomes -q -y
+		for ((i = 1; i < ${#1}; i++)); do
+			expanded_args+=("-${1:i:1}")
+		done
 
-    shift
-  done
+		shift
+	done
 
-  # Reset positional parameters to expanded arguments
-  set -- "${expanded_args[@]}"
+	# Reset positional parameters to expanded arguments
+	set -- "${expanded_args[@]}"
 
-  # Parse long arguments
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -h | --help)
-        usage
-        exit 0
-        ;;
-      -d | --dry)
-        DRY="y"
-        shift
-        ;;
-      -f | --force)
-        FORCE="$2"
+	# Parse long arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-d | --dry)
+				DRY="y"
+				shift
+				;;
+			-f | --force)
+				FORCE="$2"
 
-        if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
-          exit 1
-        fi
+				if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -l | --log)
-        LOG="$2"
+				shift 2
+				;;
+			-l | --log)
+				LOG="$2"
 
-        if [[ ! $LOG =~ ^[0-3]$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
-          exit 1
-        fi
+				if [[ ! $LOG =~ ^[0-3]$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -t | --type)
-        TYPE="$2"
+				shift 2
+				;;
+			-t | --type)
+				TYPE="$2"
 
-        if [[ ! $TYPE =~ ^(rust|bash)$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid installation type: $TYPE" >&2
-          exit 1
-        fi
+				if [[ ! $TYPE =~ ^(rust|bash)$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid installation type: $TYPE" >&2
+					exit 1
+				fi
 
-        # 1 for rust, 2 for bash
-        if [[ "$TYPE" == "rust" ]]; then
-          TYPE=1
-        else
-          TYPE=2
-        fi
+				# 1 for rust, 2 for bash
+				if [[ "$TYPE" == "rust" ]]; then
+					TYPE=1
+				else
+					TYPE=2
+				fi
 
-        shift 2
-        ;;
-      -p | --path)
-        USER_PATH="$2"
-        shift 2
-        ;;
-      -*)
-        log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
-        usage
-        exit 1
-        ;;
-      *)
-        log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
-        usage
-        exit 1
-        ;;
-    esac
-  done
+				shift 2
+				;;
+			-p | --path)
+				USER_PATH="$2"
+				shift 2
+				;;
+			-*)
+				log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+			*)
+				log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
+				usage
+				exit 1
+				;;
+		esac
+	done
 
-  # Will only happen when on verbose mode
-  log $LOG_VERBOSE "[INFO] Running verbose log level"
+	# Will only happen when on verbose mode
+	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-  if [[ "$FORCE" == "y" ]]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-  elif [[ "$FORCE" == "n" ]]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
-  else
-    log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
-  fi
+	if [[ "$FORCE" == "y" ]]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
+	elif [[ "$FORCE" == "n" ]]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
+	else
+		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
+	fi
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
+	fi
 }
 
 path_needs_sudo() {
-  local path="$1"
+	local path="$1"
 
-  while true; do
-    # Safeguard, prevent infinite loop
-    if [[ -z "$path" ]]; then
-      log $LOG_QUIET "[ERROR] Provided path is not valid: $1" >&2
-      exit 1
-    fi
-    if [[ "$path" == "/" ]]; then
-      echo "y"
-      break
-    fi
+	while true; do
+		# Safeguard, prevent infinite loop
+		if [[ -z "$path" ]]; then
+			log $LOG_QUIET "[ERROR] Provided path is not valid: $1" >&2
+			exit 1
+		fi
+		if [[ "$path" == "/" ]]; then
+			echo "y"
+			break
+		fi
 
-    # if exists, check write permissions
-    if [[ -e "$path" ]]; then
-      if [[ -w "$path" ]]; then
-        echo "n"
-        break
-      else
-        echo "y"
-        break
-      fi
-    else
-      # if doesn't exist, set path to parent directory and check again
-      path=$(dirname "$path")
-      continue
-    fi
-  done
+		# if exists, check write permissions
+		if [[ -e "$path" ]]; then
+			if [[ -w "$path" ]]; then
+				echo "n"
+				break
+			else
+				echo "y"
+				break
+			fi
+		else
+			# if doesn't exist, set path to parent directory and check again
+			path=$(dirname "$path")
+			continue
+		fi
+	done
 }
 
 prompt_for_sudo() {
-  if [[ $FORCE == "y" ]]; then
-    log $LOG_VERBOSE "[INFO] Elevating permissions to continue installation."
-  elif [[ $FORCE == "n" ]]; then
-    log $LOG_NORMAL "[INFO] Elevated (sudo) permissions needed to continue installation. Exiting..."
-    exit 0
-  else
-    # Elevate permissions? Prompt the user
-    read -p "Do you want to elevate permissions to continue installation? [y/N] " -n 1 -r
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      log $LOG_NORMAL "[INFO] Aborting..."
-      exit 0
-    fi
-  fi
+	if [[ $FORCE == "y" ]]; then
+		log $LOG_VERBOSE "[INFO] Elevating permissions to continue installation."
+	elif [[ $FORCE == "n" ]]; then
+		log $LOG_NORMAL "[INFO] Elevated (sudo) permissions needed to continue installation. Exiting..."
+		exit 0
+	else
+		# Elevate permissions? Prompt the user
+		read -p "Do you want to elevate permissions to continue installation? [y/N] " -n 1 -r
+		echo ""
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log $LOG_NORMAL "[INFO] Aborting..."
+			exit 0
+		fi
+	fi
 
-  # Elevate permissions
-  sudo -v || {
-    log $LOG_QUIET "[ERROR] Failed to elevate permissions. Exiting..." >&2
-    exit 1
-  }
+	# Elevate permissions
+	sudo -v || {
+		log $LOG_QUIET "[ERROR] Failed to elevate permissions. Exiting..." >&2
+		exit 1
+	}
 }
 
 set_sudo_command() {
-  local path="$1"
-  local use_sudo
-  local status
+	local path="$1"
+	local use_sudo
+	local status
 
-  use_sudo="$(path_needs_sudo "$path")"
-  status=$?
+	use_sudo="$(path_needs_sudo "$path")"
+	status=$?
 
-  if ((status != 0)); then
-    log $LOG_QUIET "[ERROR] Could not determine if sudo is needed. Exiting..." >&2
-    exit 1
-  fi
+	if ((status != 0)); then
+		log $LOG_QUIET "[ERROR] Could not determine if sudo is needed. Exiting..." >&2
+		exit 1
+	fi
 
-  if [[ "$use_sudo" == "y" ]]; then
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would use sudo to remove binaries from $path"
-    else
-      SUDO_COMMAND="sudo"
-      prompt_for_sudo
-    fi
-  fi
+	if [[ "$use_sudo" == "y" ]]; then
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would use sudo to remove binaries from $path"
+		else
+			SUDO_COMMAND="sudo"
+			prompt_for_sudo
+		fi
+	fi
 }
 
 set_install_path() {
-  local error=""
+	local error=""
 
-  # If path is provided, use it
-  if [[ -n "$USER_PATH" ]]; then
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would use provided path: $USER_PATH"
-    else
-      log $LOG_VERBOSE "[INFO] Using provided installation path: $USER_PATH"
-    fi
-    INSTALL_DIR="$USER_PATH"
-    CONFIG["path"]="$INSTALL_DIR"
-    return
-  fi
+	# If path is provided, use it
+	if [[ -n "$USER_PATH" ]]; then
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would use provided path: $USER_PATH"
+		else
+			log $LOG_VERBOSE "[INFO] Using provided installation path: $USER_PATH"
+		fi
+		INSTALL_DIR="$USER_PATH"
+		CONFIG["path"]="$INSTALL_DIR"
+		return
+	fi
 
-  if [[ $FORCE == "ask" ]]; then
-    while true; do
-      clear
-      read -d'' -r -n1 -p 'Where do you want to install the utilities?
+	if [[ $FORCE == "ask" ]]; then
+		while true; do
+			clear
+			read -d'' -r -n1 -p 'Where do you want to install the utilities?
   1. Default multi user path (/usr/local/bin)
   2. Multi user path (/opt/dsu)
   3. Single user path ('"$HOME"'/bin)
   4. Custom path
   q. Abort and exit
 '"$error"'Option: '
-      echo ""
+			echo ""
 
-      case "$REPLY" in
-        1)
-          INSTALL_DIR="/usr/local/bin"
-          break
-          ;;
-        2)
-          INSTALL_DIR="/opt/dsu"
-          break
-          ;;
-        3)
-          INSTALL_DIR="$HOME/bin"
-          break
-          ;;
-        4)
-          read -r -p "Enter the custom path: " -e
-          INSTALL_DIR="$REPLY"
-          break
-          ;;
-        q)
-          echo "Aborting..."
-          exit 0
-          ;;
-        *)
-          error="Invalid choice: $REPLY. "
-          ;;
-      esac
-    done
-  else
-    INSTALL_DIR="/usr/local/bin"
-    log $LOG_VERBOSE "[INFO] Using default installation path: $INSTALL_DIR"
-  fi
+			case "$REPLY" in
+				1)
+					INSTALL_DIR="/usr/local/bin"
+					break
+					;;
+				2)
+					INSTALL_DIR="/opt/dsu"
+					break
+					;;
+				3)
+					INSTALL_DIR="$HOME/bin"
+					break
+					;;
+				4)
+					read -r -p "Enter the custom path: " -e
+					INSTALL_DIR="$REPLY"
+					break
+					;;
+				q)
+					echo "Aborting..."
+					exit 0
+					;;
+				*)
+					error="Invalid choice: $REPLY. "
+					;;
+			esac
+		done
+	else
+		INSTALL_DIR="/usr/local/bin"
+		log $LOG_VERBOSE "[INFO] Using default installation path: $INSTALL_DIR"
+	fi
 
-  if [[ -z "$INSTALL_DIR" ]]; then
-    log $LOG_QUIET "[ERROR] installation path not set." >&2
-    exit 1
-  fi
+	if [[ -z "$INSTALL_DIR" ]]; then
+		log $LOG_QUIET "[ERROR] installation path not set." >&2
+		exit 1
+	fi
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would use installation path: $INSTALL_DIR"
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would use installation path: $INSTALL_DIR"
+	fi
 
-  CONFIG["path"]="$INSTALL_DIR"
+	CONFIG["path"]="$INSTALL_DIR"
 }
 
 build_rust_cli() {
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would build Rust CLI binary"
-    return
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would build Rust CLI binary"
+		return
+	fi
 
-  log $LOG_VERBOSE "[INFO] Building Rust CLI binary..."
-  log $LOG_VERBOSE "[INFO] Checking for cargo..."
+	log $LOG_VERBOSE "[INFO] Building Rust CLI binary..."
+	log $LOG_VERBOSE "[INFO] Checking for cargo..."
 
-  # Cargo installed?
-  if ! command -v cargo &>/dev/null; then
-    log $LOG_NORMAL "[WARN] Rust CLI binary not found and Cargo is not installed." >&2
-    log $LOG_NORMAL "[WARN] For information on how to install cargo, refer to https://doc.rust-lang.org/cargo/getting-started/installation.html" >&2
-    log $LOG_NORMAL "[WARN] Aborting..." >&2
-    exit 1
-  fi
+	# Cargo installed?
+	if ! command -v cargo &>/dev/null; then
+		log $LOG_NORMAL "[WARN] Rust CLI binary not found and Cargo is not installed." >&2
+		log $LOG_NORMAL "[WARN] For information on how to install cargo, refer to https://doc.rust-lang.org/cargo/getting-started/installation.html" >&2
+		log $LOG_NORMAL "[WARN] Aborting..." >&2
+		exit 1
+	fi
 
-  log $LOG_VERBOSE "[INFO] Cargo found!"
+	log $LOG_VERBOSE "[INFO] Cargo found!"
 
-  if [[ $FORCE == "n" ]]; then
-    log $LOG_NORMAL "[WARN] Rust CLI binary not found. Aborting..." >&2
-    exit 1
-  elif [[ $FORCE == "ask" ]]; then
-    # Prompt for user confirmation
-    read -p "Rust CLI binary not found. Do you want to build it now? [y/N] " -n 1 -r
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      log $LOG_NORMAL "[INFO] Aborting..."
-      exit 0
-    fi
-  fi
+	if [[ $FORCE == "n" ]]; then
+		log $LOG_NORMAL "[WARN] Rust CLI binary not found. Aborting..." >&2
+		exit 1
+	elif [[ $FORCE == "ask" ]]; then
+		# Prompt for user confirmation
+		read -p "Rust CLI binary not found. Do you want to build it now? [y/N] " -n 1 -r
+		echo ""
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log $LOG_NORMAL "[INFO] Aborting..."
+			exit 0
+		fi
+	fi
 
-  log $LOG_VERBOSE "[INFO] Running cargo build..."
+	log $LOG_VERBOSE "[INFO] Running cargo build..."
 
-  # Attempt to build the binary. Write output to log file
-  cargo build --release >"$DSU_LOG_FILE" 2>&1 || {
-    log $LOG_QUIET "[ERROR] Failed to build Rust CLI binary." >&2
-    log $LOG_QUIET "[INFO] Check the log file for more information: $DSU_LOG_FILE" >&2
-    log $LOG_QUIET "[INFO] For more information check log file: $DSU_LOG_FILE" >&2
-    tail "$DSU_LOG_FILE" >&2
-    exit 1
-  }
+	# Attempt to build the binary. Write output to log file
+	cargo build --release >"$DSU_LOG_FILE" 2>&1 || {
+		log $LOG_QUIET "[ERROR] Failed to build Rust CLI binary." >&2
+		log $LOG_QUIET "[INFO] Check the log file for more information: $DSU_LOG_FILE" >&2
+		log $LOG_QUIET "[INFO] For more information check log file: $DSU_LOG_FILE" >&2
+		tail "$DSU_LOG_FILE" >&2
+		exit 1
+	}
 
-  log $LOG_VERBOSE "[INFO] Rust CLI binary built successfully!"
+	log $LOG_VERBOSE "[INFO] Rust CLI binary built successfully!"
 }
 
 install_rust_cli() {
-  CONFIG["type"]="rust"
+	CONFIG["type"]="rust"
 
-  set_install_path
-  log $LOG_NORMAL "[INFO] Installing Rust CLI binary..."
+	set_install_path
+	log $LOG_NORMAL "[INFO] Installing Rust CLI binary..."
 
-  # Do we have the dsu binary?
-  if [[ ! -e "$CLI_SRC_PATH" ]]; then
-    build_rust_cli
-  fi
+	# Do we have the dsu binary?
+	if [[ ! -e "$CLI_SRC_PATH" ]]; then
+		build_rust_cli
+	fi
 
-  set_sudo_command "$INSTALL_DIR"
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would create installation directory: $INSTALL_DIR"
-    log $LOG_NORMAL "[DRY] Would install binary to installation directory: $INSTALL_DIR"
-    return
-  fi
+	set_sudo_command "$INSTALL_DIR"
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would create installation directory: $INSTALL_DIR"
+		log $LOG_NORMAL "[DRY] Would install binary to installation directory: $INSTALL_DIR"
+		return
+	fi
 
-  log $LOG_VERBOSE "[INFO] Creating installation directory: $INSTALL_DIR"
+	log $LOG_VERBOSE "[INFO] Creating installation directory: $INSTALL_DIR"
 
-  $SUDO_COMMAND mkdir -p "$INSTALL_DIR" || {
-    log $LOG_QUIET "Could not create installation directory: $INSTALL_DIR" >&2
-    exit 1
-  }
+	$SUDO_COMMAND mkdir -p "$INSTALL_DIR" || {
+		log $LOG_QUIET "Could not create installation directory: $INSTALL_DIR" >&2
+		exit 1
+	}
 
-  log $LOG_QUIET "[INFO] Installing binary to installation directory: $INSTALL_DIR"
+	log $LOG_QUIET "[INFO] Installing binary to installation directory: $INSTALL_DIR"
 
-  $SUDO_COMMAND install -m 755 "$CLI_SRC_PATH" "$INSTALL_DIR" || {
-    echo "Failed to install binary to installation directory: $INSTALL_DIR" >&2
-    exit 1
-  }
+	$SUDO_COMMAND install -m 755 "$CLI_SRC_PATH" "$INSTALL_DIR" || {
+		echo "Failed to install binary to installation directory: $INSTALL_DIR" >&2
+		exit 1
+	}
 
-  CONFIG_BINARIES+=("${CLI_SRC_PATH##*/}")
-  log $LOG_NORMAL "[INFO] Binary installed successfully to: $INSTALL_DIR"
+	CONFIG_BINARIES+=("${CLI_SRC_PATH##*/}")
+	log $LOG_NORMAL "[INFO] Binary installed successfully to: $INSTALL_DIR"
 }
 
 build_bash_scripts() {
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would build Bash scripts tarball"
-    return
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would build Bash scripts tarball"
+		return
+	fi
 
-  # Attempt to build the tarball
-  # Write output to log file
-  log $LOG_NORMAL "[WARN] Bash scripts tarball not found. Building..."
+	# Attempt to build the tarball
+	# Write output to log file
+	log $LOG_NORMAL "[WARN] Bash scripts tarball not found. Building..."
 
-  ./build.sh >"$DSU_LOG_FILE" 2>&1 || {
-    log $LOG_QUIET "[ERROR] Failed to build Bash scripts tarball." >&2
-    log $LOG_NORMAL "[WARN] Check the log file for more information: $DSU_LOG_FILE" >&2
-    log $LOG_NORMAL "[WARN] Last 10 lines of log file:" >&2
-    tail "$DSU_LOG_FILE" >&2
-    exit 1
-  }
+	./build.sh >"$DSU_LOG_FILE" 2>&1 || {
+		log $LOG_QUIET "[ERROR] Failed to build Bash scripts tarball." >&2
+		log $LOG_NORMAL "[WARN] Check the log file for more information: $DSU_LOG_FILE" >&2
+		log $LOG_NORMAL "[WARN] Last 10 lines of log file:" >&2
+		tail "$DSU_LOG_FILE" >&2
+		exit 1
+	}
 }
 
 bash_tarball_to_tmp() {
-  local tmp_dir
+	local tmp_dir
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would extract tarball to temporary directory"
-    return
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would extract tarball to temporary directory"
+		return
+	fi
 
-  tmp_dir=$(mktemp -d)
+	tmp_dir=$(mktemp -d)
 
-  # Extract the tarball to the temporary directory
-  tar -xzf "$tarball" -C "$tmp_dir" || {
-    log $LOG_QUIET "[ERROR] Failed to extract tarball to temporary directory: $tmp_dir" >&2
-    exit 1
-  }
+	# Extract the tarball to the temporary directory
+	tar -xzf "$tarball" -C "$tmp_dir" || {
+		log $LOG_QUIET "[ERROR] Failed to extract tarball to temporary directory: $tmp_dir" >&2
+		exit 1
+	}
 
-  # Return the temporary directory
-  # bin/ directory exists inside the tarball so we return that
-  echo "$tmp_dir/bin"
+	# Return the temporary directory
+	# bin/ directory exists inside the tarball so we return that
+	echo "$tmp_dir/bin"
 }
 
 install_bash_scripts() {
-  CONFIG["type"]="bash"
+	CONFIG["type"]="bash"
 
-  local tarball tmp_dir use_sudo
+	local tarball tmp_dir use_sudo
 
-  set_install_path
+	set_install_path
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would install standalone bash scripts"
-  else
-    log $LOG_NORMAL "[INFO] Installing standalone bash scripts..."
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would install standalone bash scripts"
+	else
+		log $LOG_NORMAL "[INFO] Installing standalone bash scripts..."
+	fi
 
-  # Do we have the tarball with the scripts?
-  # Filename should be dsu-vx.y.z.tar.gz (semver schema)
-  tarball="$BASH_SRC_DIR/dsu-$(cat VERSION).tar.gz"
+	# Do we have the tarball with the scripts?
+	# Filename should be dsu-vx.y.z.tar.gz (semver schema)
+	tarball="$BASH_SRC_DIR/dsu-$(cat VERSION).tar.gz"
 
-  if [[ ! -e "$tarball" ]]; then
-    build_bash_scripts
-  fi
+	if [[ ! -e "$tarball" ]]; then
+		build_bash_scripts
+	fi
 
-  tmp_dir=$(bash_tarball_to_tmp)
+	tmp_dir=$(bash_tarball_to_tmp)
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would extract tarball to temporary directory"
-  else
-    log $LOG_VERBOSE "[INFO] Extracted tarball to temporary directory: $tmp_dir"
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would extract tarball to temporary directory"
+	else
+		log $LOG_VERBOSE "[INFO] Extracted tarball to temporary directory: $tmp_dir"
+	fi
 
-  set_sudo_command "$INSTALL_DIR"
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would create installation directory: $INSTALL_DIR"
-    log $LOG_NORMAL "[DRY] Would install bash scripts to installation directory: $INSTALL_DIR"
-    return
-  fi
+	set_sudo_command "$INSTALL_DIR"
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would create installation directory: $INSTALL_DIR"
+		log $LOG_NORMAL "[DRY] Would install bash scripts to installation directory: $INSTALL_DIR"
+		return
+	fi
 
-  log $LOG_VERBOSE "[INFO] Creating installation directory: $INSTALL_DIR"
-  $SUDO_COMMAND mkdir -p "$INSTALL_DIR" || {
-    log $LOG_QUIET "[ERROR] Could not create installation directory: $INSTALL_DIR" >&2
-    exit 1
-  }
+	log $LOG_VERBOSE "[INFO] Creating installation directory: $INSTALL_DIR"
+	$SUDO_COMMAND mkdir -p "$INSTALL_DIR" || {
+		log $LOG_QUIET "[ERROR] Could not create installation directory: $INSTALL_DIR" >&2
+		exit 1
+	}
 
-  log $LOG_VERBOSE "[INFO] Installing bash scripts to installation directory: $INSTALL_DIR"
-  for file in "$tmp_dir"/*; do
-    log $LOG_VERBOSE "[INFO] Installing file: ${file##*/}"
-    $SUDO_COMMAND install -m 755 "$file" "$INSTALL_DIR" || {
-      log $LOG_QUIET "[ERROR] Failed to install file to installation directory: $INSTALL_DIR" >&2
-      exit 1
-    }
+	log $LOG_VERBOSE "[INFO] Installing bash scripts to installation directory: $INSTALL_DIR"
+	for file in "$tmp_dir"/*; do
+		log $LOG_VERBOSE "[INFO] Installing file: ${file##*/}"
+		$SUDO_COMMAND install -m 755 "$file" "$INSTALL_DIR" || {
+			log $LOG_QUIET "[ERROR] Failed to install file to installation directory: $INSTALL_DIR" >&2
+			exit 1
+		}
 
-    CONFIG_BINARIES+=("${file##*/}")
-  done
+		CONFIG_BINARIES+=("${file##*/}")
+	done
 
-  # Clean up the temporary directory
-  log $LOG_VERBOSE "[INFO] Cleaning up temporary directory: $tmp_dir"
-  rm -rf "$tmp_dir"
+	# Clean up the temporary directory
+	log $LOG_VERBOSE "[INFO] Cleaning up temporary directory: $tmp_dir"
+	rm -rf "$tmp_dir"
 
-  log $LOG_NORMAL "[INFO] Bash scripts installed successfully to: $INSTALL_DIR"
+	log $LOG_NORMAL "[INFO] Bash scripts installed successfully to: $INSTALL_DIR"
 }
 
 remove_previous_install() {
-  local binaries=()
-  local type=""
-  local path=""
+	local binaries=()
+	local type=""
+	local path=""
 
-  # Read the config file
-  while IFS= read -r line; do
-    # Skip comments and empty lines
-    [[ "$line" =~ ^#.* ]] && continue
-    [[ -z "$line" ]] && continue
+	# Read the config file
+	while IFS= read -r line; do
+		# Skip comments and empty lines
+		[[ "$line" =~ ^#.* ]] && continue
+		[[ -z "$line" ]] && continue
 
-    # Read type and path
-    if [[ "$line" =~ ^type= ]]; then
-      type="${line#*=}"
-    elif [[ "$line" =~ ^path= ]]; then
-      path="${line#*=}"
-    elif [[ "$line" =~ ^[[:space:]] ]]; then
-      binaries+=("${line//[[:space:]]/}")
-    fi
-  done <"$CONFIG_FILE"
+		# Read type and path
+		if [[ "$line" =~ ^type= ]]; then
+			type="${line#*=}"
+		elif [[ "$line" =~ ^path= ]]; then
+			path="${line#*=}"
+		elif [[ "$line" =~ ^[[:space:]] ]]; then
+			binaries+=("${line//[[:space:]]/}")
+		fi
+	done <"$CONFIG_FILE"
 
-  if [[ -z "$type" ]] || [[ -z "$path" ]]; then
-    log $LOG_QUIET "[ERROR] Invalid configuration file: $CONFIG_FILE" >&2
-    exit 1
-  fi
+	if [[ -z "$type" ]] || [[ -z "$path" ]]; then
+		log $LOG_QUIET "[ERROR] Invalid configuration file: $CONFIG_FILE" >&2
+		exit 1
+	fi
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would remove existing $type installation from $path"
-  else
-    log $LOG_NORMAL "[INFO] Removing existing $type installation from $path..."
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would remove existing $type installation from $path"
+	else
+		log $LOG_NORMAL "[INFO] Removing existing $type installation from $path..."
+	fi
 
-  set_sudo_command "$path"
-  for binary in "${binaries[@]}"; do
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would remove binary: $path/$binary"
-      continue
-    fi
+	set_sudo_command "$path"
+	for binary in "${binaries[@]}"; do
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would remove binary: $path/$binary"
+			continue
+		fi
 
-    log $LOG_VERBOSE "[INFO] Removing binary: $path/$binary"
-    $SUDO_COMMAND rm -f "$path/$binary" || {
-      log $LOG_QUIET "[ERROR] Failed to remove binary: $path/$binary" >&2
-      exit 1
-    }
-  done
+		log $LOG_VERBOSE "[INFO] Removing binary: $path/$binary"
+		$SUDO_COMMAND rm -f "$path/$binary" || {
+			log $LOG_QUIET "[ERROR] Failed to remove binary: $path/$binary" >&2
+			exit 1
+		}
+	done
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would remove configuration file: $CONFIG_FILE"
-    log $LOG_NORMAL "[DRY] Would remove log file: $DSU_LOG_FILE"
-    log $LOG_NORMAL "[DRY] Would remove configuration directory: $CONFIG_PATH"
-  else
-    log $LOG_VERBOSE "[INFO] Removing configuration file: $CONFIG_FILE"
-    rm "$CONFIG_FILE" 2>/dev/null || true
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would remove configuration file: $CONFIG_FILE"
+		log $LOG_NORMAL "[DRY] Would remove log file: $DSU_LOG_FILE"
+		log $LOG_NORMAL "[DRY] Would remove configuration directory: $CONFIG_PATH"
+	else
+		log $LOG_VERBOSE "[INFO] Removing configuration file: $CONFIG_FILE"
+		rm "$CONFIG_FILE" 2>/dev/null || true
 
-    log $LOG_VERBOSE "[INFO] Removing log file: $DSU_LOG_FILE"
-    rm "$DSU_LOG_FILE" 2>/dev/null || true
+		log $LOG_VERBOSE "[INFO] Removing log file: $DSU_LOG_FILE"
+		rm "$DSU_LOG_FILE" 2>/dev/null || true
 
-    log $LOG_VERBOSE "[INFO] Removing configuration directory: $CONFIG_PATH"
-    rmdir "$CONFIG_PATH" 2>/dev/null || true
+		log $LOG_VERBOSE "[INFO] Removing configuration directory: $CONFIG_PATH"
+		rmdir "$CONFIG_PATH" 2>/dev/null || true
 
-    log $LOG_NORMAL "[INFO] Uninstallation completed successfully."
-  fi
+		log $LOG_NORMAL "[INFO] Uninstallation completed successfully."
+	fi
 }
 
 pre_install() {
-  # Check for previous installation
-  if [[ ! -e "$CONFIG_FILE" ]]; then
-    log $LOG_NORMAL "[INFO] Nothing to uninstall. Configuration file not found: $CONFIG_FILE"
-    return
-  fi
+	# Check for previous installation
+	if [[ ! -e "$CONFIG_FILE" ]]; then
+		log $LOG_NORMAL "[INFO] Nothing to uninstall. Configuration file not found: $CONFIG_FILE"
+		return
+	fi
 
-  if [[ $FORCE == "y" ]]; then
-    log $LOG_NORMAL "[INFO] Previous installation found. Removing..."
-    remove_previous_install
-  elif [[ $FORCE == "n" ]]; then
-    log $LOG_QUIET "Previous installation found. Exiting..."
-    exit 0
-  else
-    echo "Looks like dsu is already installed. Proceeding will remove the existing installation."
-    read -p "Do you want to continue? [y/N] " -n 1 -r
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      echo "Aborting..."
-      exit 0
-    fi
+	if [[ $FORCE == "y" ]]; then
+		log $LOG_NORMAL "[INFO] Previous installation found. Removing..."
+		remove_previous_install
+	elif [[ $FORCE == "n" ]]; then
+		log $LOG_QUIET "Previous installation found. Exiting..."
+		exit 0
+	else
+		echo "Looks like dsu is already installed. Proceeding will remove the existing installation."
+		read -p "Do you want to continue? [y/N] " -n 1 -r
+		echo ""
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			echo "Aborting..."
+			exit 0
+		fi
 
-    remove_previous_install
-  fi
+		remove_previous_install
+	fi
 }
 
 do_install() {
-  # Skip the prompt if either force mode is set or install type is provided
-  if [[ $FORCE != "ask" ]] || [[ $TYPE != 0 ]]; then
-    case "$TYPE" in
-      1) install_rust_cli ;;
-      2) install_bash_scripts ;;
-      *) log $LOG_QUIET "[ERROR] Invalid installation type: $TYPE." >&2 ;;
-    esac
-    return
-  fi
+	# Skip the prompt if either force mode is set or install type is provided
+	if [[ $FORCE != "ask" ]] || [[ $TYPE != 0 ]]; then
+		case "$TYPE" in
+			1) install_rust_cli ;;
+			2) install_bash_scripts ;;
+			*) log $LOG_QUIET "[ERROR] Invalid installation type: $TYPE." >&2 ;;
+		esac
+		return
+	fi
 
-  local error=""
-  while true; do
-    clear
-    read -d'' -r -n1 -p 'Welcome to the dsu'\''s installer!
+	local error=""
+	while true; do
+		clear
+		read -d'' -r -n1 -p 'Welcome to the dsu'\''s installer!
 
 Currently, there are two implementations of the utilities:
 .- Rust CLI: A command-line interface written in Rust that bundles all the utilities in one place.
@@ -646,132 +646,132 @@ Please select the installation method:
   2. Bash individual scripts
   q. Abort and exit
 '"$error"'Option: '
-    echo ""
+		echo ""
 
-    case "$REPLY" in
-      1)
-        install_rust_cli
-        break
-        ;;
-      2)
-        install_bash_scripts
-        break
-        ;;
-      q) echo "Aborting..." exit 0 ;;
-      *) error="Invalid choice: $REPLY. " ;;
-    esac
-  done
+		case "$REPLY" in
+			1)
+				install_rust_cli
+				break
+				;;
+			2)
+				install_bash_scripts
+				break
+				;;
+			q) echo "Aborting..." exit 0 ;;
+			*) error="Invalid choice: $REPLY. " ;;
+		esac
+	done
 }
 
 write_to_conf() {
-  local key="$1"
-  local value="${2:-}"
+	local key="$1"
+	local value="${2:-}"
 
-  if [[ -z "$value" ]]; then
-    echo "$key" >>"$CONFIG_FILE"
-  else
-    echo "$key=$value" >>"$CONFIG_FILE"
-  fi
+	if [[ -z "$value" ]]; then
+		echo "$key" >>"$CONFIG_FILE"
+	else
+		echo "$key=$value" >>"$CONFIG_FILE"
+	fi
 }
 
 init_config() {
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would write configuration file"
-    log $LOG_NORMAL "[DRY] Would create configuration directory: $CONFIG_PATH"
-    return
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would write configuration file"
+		log $LOG_NORMAL "[DRY] Would create configuration directory: $CONFIG_PATH"
+		return
+	fi
 
-  log $LOG_NORMAL "[INFO] Writing configuration file..."
-  log $LOG_VERBOSE "[INFO] Creating configuration directory: $CONFIG_PATH"
+	log $LOG_NORMAL "[INFO] Writing configuration file..."
+	log $LOG_VERBOSE "[INFO] Creating configuration directory: $CONFIG_PATH"
 
-  mkdir -p "$CONFIG_PATH"
-  rm "$CONFIG_FILE" 2>/dev/null || true
-  touch "$CONFIG_FILE"
+	mkdir -p "$CONFIG_PATH"
+	rm "$CONFIG_FILE" 2>/dev/null || true
+	touch "$CONFIG_FILE"
 
-  write_to_conf "# Configuration file for dsu"
-  write_to_conf "# This file is used to store the installation path and other settings"
-  write_to_conf "# Do not modify this file unless you know what you are doing"
-  write_to_conf ""
-  write_to_conf "type" "${CONFIG["type"]}"
-  write_to_conf "path" "${CONFIG["path"]}"
-  write_to_conf "binaries="
-  for binary in "${CONFIG_BINARIES[@]}"; do
-    write_to_conf "    $binary"
-  done
+	write_to_conf "# Configuration file for dsu"
+	write_to_conf "# This file is used to store the installation path and other settings"
+	write_to_conf "# Do not modify this file unless you know what you are doing"
+	write_to_conf ""
+	write_to_conf "type" "${CONFIG["type"]}"
+	write_to_conf "path" "${CONFIG["path"]}"
+	write_to_conf "binaries="
+	for binary in "${CONFIG_BINARIES[@]}"; do
+		write_to_conf "    $binary"
+	done
 }
 
 post_install() {
-  local reject_msg
-  local shell_config_file
+	local reject_msg
+	local shell_config_file
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would check if installation path is in PATH environment variable"
-    return
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would check if installation path is in PATH environment variable"
+		return
+	fi
 
-  log $LOG_NORMAL "[INFO] Installation complete!"
+	log $LOG_NORMAL "[INFO] Installation complete!"
 
-  # shellcheck disable=SC2016
-  reject_msg='[INFO] Please make sure to add the installation path to your PATH environment variable.
+	# shellcheck disable=SC2016
+	reject_msg='[INFO] Please make sure to add the installation path to your PATH environment variable.
 [INFO] For example, add the following line to your shell configuration file:
   export PATH="$PATH:'"$INSTALL_DIR"'"'
 
-  log $LOG_VERBOSE "[INFO] Checking if installation path is in PATH environment variable..."
-  for path in $(echo "$PATH" | tr ':' '\n' | sort | uniq); do
-    if [[ "$path" == "$INSTALL_DIR" ]]; then
-      return
-    fi
-  done
+	log $LOG_VERBOSE "[INFO] Checking if installation path is in PATH environment variable..."
+	for path in $(echo "$PATH" | tr ':' '\n' | sort | uniq); do
+		if [[ "$path" == "$INSTALL_DIR" ]]; then
+			return
+		fi
+	done
 
-  log $LOG_VERBOSE "[INFO] Installation path not found in PATH environment variable."
-  case "$SHELL" in
-    */bash)
-      shell_config_file="$HOME/.bashrc"
-      ;;
-    */zsh)
-      shell_config_file="$HOME/.zshrc"
-      ;;
-    *)
-      shell_config_file=""
-      ;;
-  esac
+	log $LOG_VERBOSE "[INFO] Installation path not found in PATH environment variable."
+	case "$SHELL" in
+		*/bash)
+			shell_config_file="$HOME/.bashrc"
+			;;
+		*/zsh)
+			shell_config_file="$HOME/.zshrc"
+			;;
+		*)
+			shell_config_file=""
+			;;
+	esac
 
-  if [[ ! -w "$shell_config_file" ]]; then
-    echo "$reject_msg"
-  else
-    if [[ $FORCE == "y" ]]; then
-      echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >>"$shell_config_file"
-      log $LOG_NORMAL "[INFO] Installation path added to PATH environment variable."
-    elif [[ $FORCE == "n" ]]; then
-      echo "$reject_msg"
-    else
-      # Prompt the user to add the installation path to the PATH environment variable
-      read -p "Do you want to add it now? [y/N] " -n 1 -r
-      echo ""
-      if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >>"$shell_config_file"
-        log $LOG_NORMAL "[INFO] Installation path added to PATH environment variable."
-      else
-        echo "$reject_msg"
-      fi
-    fi
-  fi
+	if [[ ! -w "$shell_config_file" ]]; then
+		echo "$reject_msg"
+	else
+		if [[ $FORCE == "y" ]]; then
+			echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >>"$shell_config_file"
+			log $LOG_NORMAL "[INFO] Installation path added to PATH environment variable."
+		elif [[ $FORCE == "n" ]]; then
+			echo "$reject_msg"
+		else
+			# Prompt the user to add the installation path to the PATH environment variable
+			read -p "Do you want to add it now? [y/N] " -n 1 -r
+			echo ""
+			if [[ $REPLY =~ ^[Yy]$ ]]; then
+				echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >>"$shell_config_file"
+				log $LOG_NORMAL "[INFO] Installation path added to PATH environment variable."
+			else
+				echo "$reject_msg"
+			fi
+		fi
+	fi
 
-  log $LOG_NORMAL "[INFO] Do not forget to source your shell configuration file to apply the changes."
-  echo "    source $shell_config_file"
+	log $LOG_NORMAL "[INFO] Do not forget to source your shell configuration file to apply the changes."
+	echo "    source $shell_config_file"
 }
 
 main() {
-  arg_parse "$@"
+	arg_parse "$@"
 
-  pre_install
+	pre_install
 
-  # These functions can call exit on failure
-  # So, we don't need to check for errors here
-  # PD: Is this a good practice?
-  do_install
-  init_config
-  post_install
+	# These functions can call exit on failure
+	# So, we don't need to check for errors here
+	# PD: Is this a good practice?
+	do_install
+	init_config
+	post_install
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -254,9 +254,8 @@ prompt_for_sudo() {
 }
 
 set_sudo_command() {
+	local use_sudo status
 	local path="$1"
-	local use_sudo
-	local status
 
 	use_sudo="$(path_needs_sudo "$path")"
 	status=$?

--- a/sh/backup.sh
+++ b/sh/backup.sh
@@ -94,7 +94,7 @@ check_version() {
 	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
 	# strip leading and trailing whitespace
-	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
 	if [[ "$remote_version" != "$VERSION" ]]; then
@@ -114,22 +114,22 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [[ "$LOG" -ge $LOG_QUIET ]]; then
+			if ((LOG >= LOG_QUIET)); then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
+			if ((LOG >= LOG_NORMAL)); then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
+			if ((LOG >= LOG_VERBOSE)); then
 				echo "$message"
 			fi
 			;;
 		*)
-			echo "[ERROR] Invalid log level: $level" >&2
+			log $LOG_QUIET "[ERROR] Invalid log level: $level" >&2
 			exit 1
 			;;
 	esac
@@ -138,7 +138,7 @@ log() {
 arg_parse() {
 	# Expand combined short options (e.g., -qy to -q -y)
 	expanded_args=()
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
 		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
 			expanded_args+=("$1")
@@ -160,7 +160,7 @@ arg_parse() {
 	set -- "${expanded_args[@]}"
 
 	# Parse long arguments
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case "$1" in
 			-h | --help)
 				usage
@@ -219,7 +219,7 @@ arg_parse() {
 	done
 
 	# Default to current directory if backup directory not provided
-	TARGET="${TARGET:-$(pwd)}"
+	${TARGET:=$(pwd)}
 
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
@@ -290,7 +290,7 @@ run() {
 	local filename
 	local timestamp
 
-	filename=$(basename "$SOURCE")
+	filename=${SOURCE##*/}
 	timestamp=$(date +%Y-%m-%d_%H-%M-%S)
 
 	local backup_path="$TARGET/$filename.$timestamp.bak"

--- a/sh/backup.sh
+++ b/sh/backup.sh
@@ -11,21 +11,24 @@
 
 set -uo pipefail
 
-version="v2.1.30"
+# App data
 app=${0##*/}
+version="v2.1.30"
 
 # Log levels
-#log_silent=0
-log_quiet=1
-log_normal=2
-log_verbose=3
+log_silent=0
+log_error=1
+log_warn=2
+log_dry=3
+log_info=4
+log_verbose=5
+log=$log_info
 
 # Args and options
 source=""
 target=""
 dry="n"
 force="ask"
-log=$log_normal
 
 usage() {
 	cat <<EOF
@@ -33,52 +36,71 @@ Usage: $app [options] <source> [target]
 
 Create a timestamped backup of a file or directory.
 
-Arguments:
-  [options]               Additional options to customize the behavior.
-  <source>                The path to the file, directory, or symlink to back up.
-  [target]                Optional. The directory where file backup will be stored. Defaults to the current directory.
+Arguments
+	[options]
+		Additional options to customize the behavior.
 
-Options:
-  -h, --help              Display this help message and exit
-  -v, --version           Display the version of this script and exit
-  -d, --dry               Dry run. Print the operations that would be performed without actually executing them.
-  -f, --force <y/n/ask>
-                          Force mode. One of (ask by default):
-                            - y: Automatic yes to prompts. Assume "yes" as the answer to all prompts and run non-interactively.
-                            - n: Automatic no to prompts. Assume "no" as the answer to all prompts and run non-interactively.
-                            - ask: Prompt for confirmation before overwriting existing backups. This is the default behavior.
-  -l, --log <level>
-                          Log level. One of (2 by default):
-                            - 0: Silent mode. No output
-                            - 1: Quiet mode. Only errors
-                            - 2: Normal mode. Errors warnings and information. This is the default behavior.
-                            - 3: Verbose mode. Detailed information about the operations being performed.
-  -c, --check-version     Checks the version of this script against the remote repo version and prints a message on how to update.
+	<source>
+		Required. The path to the file, directory, or symlink to back up.
 
-Behavior:
-  Creates a backup file with a timestamp in the name to avoid overwriting previous backups.
-  If the backup directory is not specified, the backup file will be created in the current directory.
-  If the backup directory does not exist, it will be created (assuming the correct permissions are set).
-  By default, the script will prompt for confirmation before overwriting existing backups unless the force mode is set to 'y' or 'n'.
+	[target]
+		Optional. The directory where file backup will be stored. Defaults to the current directory.
 
-Naming Convention:
-  Backup files will be named as follows:
-    <target>/<filename>.<timestamp>.bak
-  Where timestamp is in the format: YYYY-MM-DD_hh-mm-ss
-  Example:
-    /home/user/backups/hosts.2024-07-04_12-00-00.bak
+Options
+	-h, --help
+		Display this help message and exit
 
-Examples:
-  Create a backup of /etc/hosts in the current directory:
-    $app -b /etc/hosts
+	-v, --version
+		Display the version of this script and exit
 
-  Create a backup of /etc/hosts in /home/user/backups:
-    $app -b /etc/hosts /home/user/backups
+	-d, --dry
+		Dry run. Print the operations that would be performed without actually executing them.
 
-Note:
-- Ensure you have the necessary permissions to read/write files and directories involved in the operations.
-- For large directories, the backup and restore operations might take some time as all the file tree needs to be copied.
-- Long arguments will take priority over short arguments, so if e.g. both --backup and -r are provided, the script will perform a backup.
+	-f, --force <y/n/ask>
+		Force mode. One of (ask by default):
+			- y: Automatic yes to prompts. Assume "yes" as the answer to all prompts and run non-interactively.
+			- n: Automatic no to prompts. Assume "no" as the answer to all prompts and run non-interactively.
+			- ask: Prompt for confirmation before overwriting existing backups. This is the default behavior.
+
+	-l, --log <level>
+		Log level. One of (4 by default):
+			- 0: Silent mode. No output
+			- 1: Error mode. Only errors
+			- 2: Warn mode. Errors and warnings
+			- 3: Dry mode. Errors, warnings, and dry run information
+			- 4: Info mode. Errors, warnings, and informational messages (default)
+			- 5: Verbose mode. Detailed information about the operations being performed
+
+	-c, --check-version
+		Checks the version of this script against the remote repo version and prints a message on how to update.
+
+Behavior
+	Creates a backup file with a timestamp in the name to avoid overwriting previous backups.
+	If the backup directory is not specified, the backup file will be created in the current directory.
+	If the backup directory does not exist, it will be created (assuming the correct permissions are set).
+	By default, the script will prompt for confirmation before overwriting existing backups unless the force mode is set to 'y' or 'n'.
+
+Naming Convention
+	Backup files will be named as follows:
+	  <target>/<filename>.<timestamp>.bak
+
+	Where timestamp is in the format YYYY-MM-DD_hh-mm-ss, like so
+	  /home/user/backups/hosts.2024-07-04_12-00-00.bak
+
+Examples
+	Create a backup of /etc/hosts in the current directory:
+	  $app /etc/hosts
+
+	Create a backup of /etc/hosts in /home/user/backups:
+	  $app /etc/hosts /home/user/backups
+
+	Perform a silent backup without prompts:
+		$app -l 0 -f y /etc/hosts /home/user/backups
+
+Note
+	- Ensure you have the necessary permissions to read/write files and directories involved in the operations.
+	- For large directories, the backup and restore operations might take some time as all the file tree needs to be copied.
+	- Long arguments will take priority over short arguments, so if e.g. both --backup and -r are provided, the script will perform a backup.
 EOF
 }
 
@@ -108,31 +130,24 @@ check_version() {
 log() {
 	local level="$1"
 	local message="$2"
+	local levels=("SILENT" "ERROR" "WARN" "DRY" "INFO" "VERBOSE")
+	local log_level=(
+		"$log_silent"
+		"$log_error"
+		"$log_warn"
+		"$log_dry"
+		"$log_info"
+		"$log_verbose"
+	)
 
-	case "$level" in
-		0)
-			# Silent mode. No output
-			;;
-		1)
-			if ((log >= log_quiet)); then
-				echo "$message"
-			fi
-			;;
-		2)
-			if ((log >= log_normal)); then
-				echo "$message"
-			fi
-			;;
-		3)
-			if ((log >= log_verbose)); then
-				echo "$message"
-			fi
-			;;
-		*)
-			log $log_quiet "[ERROR] Invalid log level: $level" >&2
-			exit 1
-			;;
-	esac
+	#	 Assert log level is valid
+	((level >= 0 && level <= 4)) || {
+		log $log_warn "Invalid log level: $level" >&2
+		return
+	}
+
+	#	Assert message should be printed
+	((log >= log_level[level])) && echo "[${levels[level]}] $message"
 }
 
 arg_parse() {
@@ -182,7 +197,7 @@ arg_parse() {
 				force="$2"
 
 				if [[ ! $force =~ ^(y|n|ask)$ ]]; then
-					log $log_quiet "[ERROR] Invalid force mode: $force" >&2
+					log $log_error "Invalid force mode: $force" >&2
 					exit 1
 				fi
 
@@ -192,14 +207,14 @@ arg_parse() {
 				log="$2"
 
 				if [[ ! $log =~ ^[0-3]$ ]]; then
-					log $log_quiet "[ERROR] Invalid log level: $log" >&2
+					log $log_error "Invalid log level: $log" >&2
 					exit 1
 				fi
 
 				shift 2
 				;;
 			-*)
-				log $log_quiet "[ERROR] Unknown option: $1" >&2
+				log $log_error "Unknown option: $1" >&2
 				usage
 				exit 1
 				;;
@@ -209,7 +224,7 @@ arg_parse() {
 				elif [[ -z "$target" ]]; then
 					target="$1"
 				else
-					log $log_quiet "[ERROR] Unknown argument: $1" >&2
+					log $log_error "Unknown argument: $1" >&2
 					usage
 					exit 1
 				fi
@@ -222,27 +237,27 @@ arg_parse() {
 	${target:=.}
 
 	# Will only happen when on verbose mode
-	log $log_verbose "[INFO] Running verbose log level"
+	log $log_verbose "Running verbose log level"
 
 	if [[ "$force" == "y" ]]; then
-		log $log_verbose "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
+		log $log_verbose "Running non-interactive mode. Assuming 'yes' for all prompts."
 	elif [[ "$force" == "n" ]]; then
-		log $log_verbose "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
+		log $log_verbose "Running non-interactive mode. Assuming 'no' for all prompts."
 	else
-		log $log_verbose "[INFO] Running interactive mode. Will prompt for confirmation."
+		log $log_verbose "Running interactive mode. Will prompt for confirmation."
 	fi
 
 	if [[ $dry == "y" ]]; then
-		log $log_verbose "[INFO] Running dry run mode. No changes will be made."
+		log $log_verbose "Running dry run mode. No changes will be made."
 	fi
 }
 
 prepare_source() {
 	if [[ ! -e "$source" ]]; then
-		log $log_quiet "[ERROR] Source not found: $source" >&2
+		log $log_error "Source not found: $source" >&2
 		exit 1
 	elif [[ ! -r "$source" ]]; then
-		log $log_quiet "[ERROR] Permission denied: $source" >&2
+		log $log_error "Permission denied: $source" >&2
 		exit 1
 	fi
 }
@@ -250,38 +265,38 @@ prepare_source() {
 prepare_target() {
 	if [[ ! -e "$target" ]]; then
 		if [[ $dry == "y" ]]; then
-			log $log_normal "[dry] Would create backup directory: $target"
+			log $log_dry "Would create backup directory: $target"
 			return
 		fi
 
 		if [[ $force == "y" ]]; then
-			log $log_verbose "[INFO] Creating backup directory: $target"
+			log $log_verbose "Creating backup directory: $target"
 			mkdir -p "$target" || {
-				log $log_quiet "[ERROR] Could not create backup directory: $target" >&2
+				log $log_error "Could not create backup directory: $target" >&2
 				exit 1
 			}
 		elif [[ $force == "n" ]]; then
-			log $log_quiet "[ERROR] Backup directory does not exist, exiting: $target" >&2
+			log $log_error "Backup directory does not exist, exiting: $target" >&2
 			exit 1
 		else
 			read -p "[WARN] Backup directory does not exist. Create? [y/N] " -n 1 -r
 			echo ""
 			if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-				log $log_normal "[INFO] Exiting..."
+				$log_info "Exiting..."
 				exit 0
 			else
-				log $log_verbose "[INFO] Creating backup directory: $target"
+				log $log_verbose "Creating backup directory: $target"
 				mkdir -p "$target" || {
-					log $log_quiet "[ERROR] Could not create backup directory: $target" >&2
+					log $log_error "Could not create backup directory: $target" >&2
 					exit 1
 				}
 			fi
 		fi
 	elif [[ ! -d "$target" ]]; then
-		log $log_quiet "[ERROR] Not a directory: $target" >&2
+		log $log_error "Not a directory: $target" >&2
 		exit 1
 	elif [[ ! -w "$target" ]]; then
-		log $log_quiet "[ERROR] Permission denied: $target" >&2
+		log $log_error "Permission denied: $target" >&2
 		exit 1
 	fi
 }
@@ -293,20 +308,20 @@ run() {
 	timestamp=$(date +%Y-%m-%d_%H-%M-%S)
 	backup_path="$target/$filename.$timestamp.bak"
 
-	log $log_verbose "[INFO] Creating file backup: $source"
-	log $log_verbose "[INFO] To backup target: $backup_path"
+	log $log_verbose "Creating file backup: $source"
+	log $log_verbose "To backup target: $backup_path"
 
 	if [[ -e "$backup_path" ]]; then
 		if [[ $dry == "y" ]]; then
-			log $log_normal "[dry] Would remove existing backup: $backup_path"
+			log $log_dry "Would remove existing backup: $backup_path"
 		elif [[ "$force" == "y" ]]; then
-			log $log_verbose "[INFO] Removing existing backup: $backup_path"
+			log $log_verbose "Removing existing backup: $backup_path"
 			rm -rf "$backup_path"
 		elif [[ "$force" == "n" ]]; then
-			log $log_normal "[INFO] Backup target already exists: $backup_path. Exiting..."
+			$log_info "Backup target already exists: $backup_path. Exiting..."
 			exit 0
 		else
-			log $log_normal "[WARN] Backup target already exists: $backup_path"
+			log $log_warn "Backup target already exists: $backup_path"
 			read -p "Overwrite backup? [y/N] " -n 1 -r
 			echo ""
 			if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -316,7 +331,7 @@ run() {
 	fi
 
 	if [[ $dry == "y" ]]; then
-		log $log_normal "[dry] Would create backup: $backup_path"
+		log $log_dry "Would create backup: $backup_path"
 	else
 		# create the backup
 		if [[ -d "$source" ]]; then
@@ -325,7 +340,7 @@ run() {
 			cp "$source" "$backup_path"
 		fi
 
-		log $log_normal "[INFO] Created backup: $backup_path"
+		$log_info "Created backup: $backup_path"
 	fi
 }
 

--- a/sh/backup.sh
+++ b/sh/backup.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 #
+# Perform a timestamped backup of a file or directory.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 VERSION="v2.1.30"
+app=${0##*/}
 
 # Log levels
 #LOG_SILENT=0
@@ -20,8 +28,8 @@ FORCE="ask"
 LOG=$LOG_NORMAL
 
 usage() {
-  cat <<EOF
-Usage: $(basename "$0") [options] <source> [target]
+	cat <<EOF
+Usage: $app [options] <source> [target]
 
 Create a timestamped backup of a file or directory.
 
@@ -62,10 +70,10 @@ Naming Convention:
 
 Examples:
   Create a backup of /etc/hosts in the current directory:
-    $(basename "$0") -b /etc/hosts
+    $app -b /etc/hosts
 
   Create a backup of /etc/hosts in /home/user/backups:
-    $(basename "$0") -b /etc/hosts /home/user/backups
+    $app -b /etc/hosts /home/user/backups
 
 Note:
 - Ensure you have the necessary permissions to read/write files and directories involved in the operations.
@@ -75,261 +83,261 @@ EOF
 }
 
 version() {
-  echo "$(basename "$0") version $VERSION"
+	echo "$app version $VERSION"
 }
 
 check_version() {
-  echo "[INFO] Current version: $VERSION"
-  echo "[INFO] Checking for updates..."
+	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Checking for updates..."
 
-  local remote_version
-  remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	local remote_version
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
-  # strip leading and trailing whitespace
-  remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	# strip leading and trailing whitespace
+	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
-  # Check if the remote version is different from the local version
-  if [ "$remote_version" != "$VERSION" ]; then
-    echo "[INFO] A new version of $(basename "$0") ($remote_version) is available!"
-    echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
-  else
-    echo "[INFO] You are running the latest version of $(basename "$0")."
-  fi
+	# Check if the remote version is different from the local version
+	if [ "$remote_version" != "$VERSION" ]; then
+		echo "[INFO] A new version of $app ($remote_version) is available!"
+		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
+	else
+		echo "[INFO] You are running the latest version of $app."
+	fi
 }
 
 log() {
-  local level="$1"
-  local message="$2"
+	local level="$1"
+	local message="$2"
 
-  case "$level" in
-  0)
-    # Silent mode. No output
-    ;;
-  1)
-    if [ "$LOG" -ge $LOG_QUIET ]; then
-      echo "$message"
-    fi
-    ;;
-  2)
-    if [ "$LOG" -ge $LOG_NORMAL ]; then
-      echo "$message"
-    fi
-    ;;
-  3)
-    if [ "$LOG" -ge $LOG_VERBOSE ]; then
-      echo "$message"
-    fi
-    ;;
-  *)
-    echo "[ERROR] Invalid log level: $level" >&2
-    exit 1
-    ;;
-  esac
+	case "$level" in
+		0)
+			# Silent mode. No output
+			;;
+		1)
+			if [ "$LOG" -ge $LOG_QUIET ]; then
+				echo "$message"
+			fi
+			;;
+		2)
+			if [ "$LOG" -ge $LOG_NORMAL ]; then
+				echo "$message"
+			fi
+			;;
+		3)
+			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+				echo "$message"
+			fi
+			;;
+		*)
+			echo "[ERROR] Invalid log level: $level" >&2
+			exit 1
+			;;
+	esac
 }
 
 arg_parse() {
-  # Expand combined short options (e.g., -qy to -q -y)
-  expanded_args=()
-  while [[ $# -gt 0 ]]; do
-    # If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
-    if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
-      expanded_args+=("$1")
-      shift
-      continue
-    fi
+	# Expand combined short options (e.g., -qy to -q -y)
+	expanded_args=()
+	while [[ $# -gt 0 ]]; do
+		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
+		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
+			expanded_args+=("$1")
+			shift
+			continue
+		fi
 
-    # Iterate over all combined short options
-    # and expand them into separate arguments
-    # eg. -qy becomes -q -y
-    for ((i = 1; i < ${#1}; i++)); do
-      expanded_args+=("-${1:i:1}")
-    done
+		# Iterate over all combined short options
+		# and expand them into separate arguments
+		# eg. -qy becomes -q -y
+		for ((i = 1; i < ${#1}; i++)); do
+			expanded_args+=("-${1:i:1}")
+		done
 
-    shift
-  done
+		shift
+	done
 
-  # Reset positional parameters to expanded arguments
-  set -- "${expanded_args[@]}"
+	# Reset positional parameters to expanded arguments
+	set -- "${expanded_args[@]}"
 
-  # Parse long arguments
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    -v | --version)
-      version
-      exit 0
-      ;;
-    -c | --check-version)
-      check_version
-      exit 0
-      ;;
-    -d | --dry)
-      DRY="y"
-      shift
-      ;;
-    -f | --force)
-      FORCE="$2"
+	# Parse long arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-v | --version)
+				version
+				exit 0
+				;;
+			-c | --check-version)
+				check_version
+				exit 0
+				;;
+			-d | --dry)
+				DRY="y"
+				shift
+				;;
+			-f | --force)
+				FORCE="$2"
 
-      if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
-        log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
-        exit 1
-      fi
+				if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
+					exit 1
+				fi
 
-      shift 2
-      ;;
-    -l | --log)
-      LOG="$2"
+				shift 2
+				;;
+			-l | --log)
+				LOG="$2"
 
-      if [[ ! $LOG =~ ^[0-3]$ ]]; then
-        log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
-        exit 1
-      fi
+				if [[ ! $LOG =~ ^[0-3]$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
+					exit 1
+				fi
 
-      shift 2
-      ;;
-    -*)
-      log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
-      usage
-      exit 1
-      ;;
-    *)
-      if [ -z "$SOURCE" ]; then
-        SOURCE="$1"
-      elif [ -z "$TARGET" ]; then
-        TARGET="$1"
-      else
-        log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
-        usage
-        exit 1
-      fi
-      shift
-      ;;
-    esac
-  done
+				shift 2
+				;;
+			-*)
+				log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+			*)
+				if [ -z "$SOURCE" ]; then
+					SOURCE="$1"
+				elif [ -z "$TARGET" ]; then
+					TARGET="$1"
+				else
+					log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
+					usage
+					exit 1
+				fi
+				shift
+				;;
+		esac
+	done
 
-  # Default to current directory if backup directory not provided
-  TARGET="${TARGET:-$(pwd)}"
+	# Default to current directory if backup directory not provided
+	TARGET="${TARGET:-$(pwd)}"
 
-  # Will only happen when on verbose mode
-  log $LOG_VERBOSE "[INFO] Running verbose log level"
+	# Will only happen when on verbose mode
+	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-  if [ "$FORCE" == "y" ]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-  elif [ "$FORCE" == "n" ]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
-  else
-    log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
-  fi
+	if [ "$FORCE" == "y" ]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
+	elif [ "$FORCE" == "n" ]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
+	else
+		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
+	fi
 
-  if [ $DRY == "y" ]; then
-    log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
-  fi
+	if [ $DRY == "y" ]; then
+		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
+	fi
 }
 
 prepare_source() {
-  if [ ! -e "$SOURCE" ]; then
-    log $LOG_QUIET "[ERROR] Source not found: $SOURCE" >&2
-    exit 1
-  elif [ ! -r "$SOURCE" ]; then
-    log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
-    exit 1
-  fi
+	if [ ! -e "$SOURCE" ]; then
+		log $LOG_QUIET "[ERROR] Source not found: $SOURCE" >&2
+		exit 1
+	elif [ ! -r "$SOURCE" ]; then
+		log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
+		exit 1
+	fi
 }
 
 prepare_target() {
-  if [ ! -e "$TARGET" ]; then
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would create backup directory: $TARGET"
-      return
-    fi
+	if [ ! -e "$TARGET" ]; then
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would create backup directory: $TARGET"
+			return
+		fi
 
-    if [[ $FORCE == "y" ]]; then
-      log $LOG_VERBOSE "[INFO] Creating backup directory: $TARGET"
-      mkdir -p "$TARGET" || {
-        log $LOG_QUIET "[ERROR] Could not create backup directory: $TARGET" >&2
-        exit 1
-      }
-    elif [[ $FORCE == "n" ]]; then
-      log $LOG_QUIET "[ERROR] Backup directory does not exist, exiting: $TARGET" >&2
-      exit 1
-    else
-      read -p "[WARN] Backup directory does not exist. Create? [y/N] " -n 1 -r
-      echo ""
-      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        log $LOG_NORMAL "[INFO] Exiting..."
-        exit 0
-      else
-        log $LOG_VERBOSE "[INFO] Creating backup directory: $TARGET"
-        mkdir -p "$TARGET" || {
-          log $LOG_QUIET "[ERROR] Could not create backup directory: $TARGET" >&2
-          exit 1
-        }
-      fi
-    fi
-  elif [ ! -d "$TARGET" ]; then
-    log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
-    exit 1
-  elif [ ! -w "$TARGET" ]; then
-    log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
-    exit 1
-  fi
+		if [[ $FORCE == "y" ]]; then
+			log $LOG_VERBOSE "[INFO] Creating backup directory: $TARGET"
+			mkdir -p "$TARGET" || {
+				log $LOG_QUIET "[ERROR] Could not create backup directory: $TARGET" >&2
+				exit 1
+			}
+		elif [[ $FORCE == "n" ]]; then
+			log $LOG_QUIET "[ERROR] Backup directory does not exist, exiting: $TARGET" >&2
+			exit 1
+		else
+			read -p "[WARN] Backup directory does not exist. Create? [y/N] " -n 1 -r
+			echo ""
+			if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+				log $LOG_NORMAL "[INFO] Exiting..."
+				exit 0
+			else
+				log $LOG_VERBOSE "[INFO] Creating backup directory: $TARGET"
+				mkdir -p "$TARGET" || {
+					log $LOG_QUIET "[ERROR] Could not create backup directory: $TARGET" >&2
+					exit 1
+				}
+			fi
+		fi
+	elif [ ! -d "$TARGET" ]; then
+		log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
+		exit 1
+	elif [ ! -w "$TARGET" ]; then
+		log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
+		exit 1
+	fi
 }
 
 run() {
-  local filename
-  local timestamp
+	local filename
+	local timestamp
 
-  filename=$(basename "$SOURCE")
-  timestamp=$(date +%Y-%m-%d_%H-%M-%S)
+	filename=$(basename "$SOURCE")
+	timestamp=$(date +%Y-%m-%d_%H-%M-%S)
 
-  local backup_path="$TARGET/$filename.$timestamp.bak"
+	local backup_path="$TARGET/$filename.$timestamp.bak"
 
-  log $LOG_VERBOSE "[INFO] Creating file backup: $SOURCE"
-  log $LOG_VERBOSE "[INFO] To backup target: $backup_path"
+	log $LOG_VERBOSE "[INFO] Creating file backup: $SOURCE"
+	log $LOG_VERBOSE "[INFO] To backup target: $backup_path"
 
-  if [ -e "$backup_path" ]; then
-    if [ $DRY == "y" ]; then
-      log $LOG_NORMAL "[DRY] Would remove existing backup: $backup_path"
-    elif [ "$FORCE" == "y" ]; then
-      log $LOG_VERBOSE "[INFO] Removing existing backup: $backup_path"
-      rm -rf "$backup_path"
-    elif [ "$FORCE" == "n" ]; then
-      log $LOG_NORMAL "[INFO] Backup target already exists: $backup_path. Exiting..."
-      exit 0
-    else
-      log $LOG_NORMAL "[WARN] Backup target already exists: $backup_path"
-      read -p "Overwrite backup? [y/N] " -n 1 -r
-      echo ""
-      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 0
-      fi
-    fi
-  fi
+	if [ -e "$backup_path" ]; then
+		if [ $DRY == "y" ]; then
+			log $LOG_NORMAL "[DRY] Would remove existing backup: $backup_path"
+		elif [ "$FORCE" == "y" ]; then
+			log $LOG_VERBOSE "[INFO] Removing existing backup: $backup_path"
+			rm -rf "$backup_path"
+		elif [ "$FORCE" == "n" ]; then
+			log $LOG_NORMAL "[INFO] Backup target already exists: $backup_path. Exiting..."
+			exit 0
+		else
+			log $LOG_NORMAL "[WARN] Backup target already exists: $backup_path"
+			read -p "Overwrite backup? [y/N] " -n 1 -r
+			echo ""
+			if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+				exit 0
+			fi
+		fi
+	fi
 
-  if [ $DRY == "y" ]; then
-    log $LOG_NORMAL "[DRY] Would create backup: $backup_path"
-  else
-    # create the backup
-    if [ -d "$SOURCE" ]; then
-      cp -r "$SOURCE" "$backup_path"
-    else
-      cp "$SOURCE" "$backup_path"
-    fi
+	if [ $DRY == "y" ]; then
+		log $LOG_NORMAL "[DRY] Would create backup: $backup_path"
+	else
+		# create the backup
+		if [ -d "$SOURCE" ]; then
+			cp -r "$SOURCE" "$backup_path"
+		else
+			cp "$SOURCE" "$backup_path"
+		fi
 
-    log $LOG_NORMAL "[INFO] Created backup: $backup_path"
-  fi
+		log $LOG_NORMAL "[INFO] Created backup: $backup_path"
+	fi
 }
 
 main() {
-  arg_parse "$@"
+	arg_parse "$@"
 
-  prepare_source
-  prepare_target
+	prepare_source
+	prepare_target
 
-  run
+	run
 }
 
 main "$@"

--- a/sh/backup.sh
+++ b/sh/backup.sh
@@ -219,7 +219,7 @@ arg_parse() {
 	done
 
 	# Default to current directory if backup directory not provided
-	${TARGET:=$(pwd)}
+	${TARGET:=.}
 
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
@@ -287,13 +287,11 @@ prepare_target() {
 }
 
 run() {
-	local filename
-	local timestamp
+	local filename timestamp backup_path
 
 	filename=${SOURCE##*/}
 	timestamp=$(date +%Y-%m-%d_%H-%M-%S)
-
-	local backup_path="$TARGET/$filename.$timestamp.bak"
+	backup_path="$TARGET/$filename.$timestamp.bak"
 
 	log $LOG_VERBOSE "[INFO] Creating file backup: $SOURCE"
 	log $LOG_VERBOSE "[INFO] To backup target: $backup_path"
@@ -333,10 +331,8 @@ run() {
 
 main() {
 	arg_parse "$@"
-
 	prepare_source
 	prepare_target
-
 	run
 }
 

--- a/sh/backup.sh
+++ b/sh/backup.sh
@@ -97,7 +97,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -114,17 +114,17 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [ "$LOG" -ge $LOG_QUIET ]; then
+			if [[ "$LOG" -ge $LOG_QUIET ]]; then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [ "$LOG" -ge $LOG_NORMAL ]; then
+			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
 				echo "$message"
 			fi
 			;;
@@ -204,9 +204,9 @@ arg_parse() {
 				exit 1
 				;;
 			*)
-				if [ -z "$SOURCE" ]; then
+				if [[ -z "$SOURCE" ]]; then
 					SOURCE="$1"
-				elif [ -z "$TARGET" ]; then
+				elif [[ -z "$TARGET" ]]; then
 					TARGET="$1"
 				else
 					log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
@@ -224,31 +224,31 @@ arg_parse() {
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-	if [ "$FORCE" == "y" ]; then
+	if [[ "$FORCE" == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-	elif [ "$FORCE" == "n" ]; then
+	elif [[ "$FORCE" == "n" ]]; then
 		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
 	else
 		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
 	fi
 
-	if [ $DRY == "y" ]; then
+	if [[ $DRY == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
 	fi
 }
 
 prepare_source() {
-	if [ ! -e "$SOURCE" ]; then
+	if [[ ! -e "$SOURCE" ]]; then
 		log $LOG_QUIET "[ERROR] Source not found: $SOURCE" >&2
 		exit 1
-	elif [ ! -r "$SOURCE" ]; then
+	elif [[ ! -r "$SOURCE" ]]; then
 		log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
 		exit 1
 	fi
 }
 
 prepare_target() {
-	if [ ! -e "$TARGET" ]; then
+	if [[ ! -e "$TARGET" ]]; then
 		if [[ $DRY == "y" ]]; then
 			log $LOG_NORMAL "[DRY] Would create backup directory: $TARGET"
 			return
@@ -277,10 +277,10 @@ prepare_target() {
 				}
 			fi
 		fi
-	elif [ ! -d "$TARGET" ]; then
+	elif [[ ! -d "$TARGET" ]]; then
 		log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
 		exit 1
-	elif [ ! -w "$TARGET" ]; then
+	elif [[ ! -w "$TARGET" ]]; then
 		log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
 		exit 1
 	fi
@@ -298,13 +298,13 @@ run() {
 	log $LOG_VERBOSE "[INFO] Creating file backup: $SOURCE"
 	log $LOG_VERBOSE "[INFO] To backup target: $backup_path"
 
-	if [ -e "$backup_path" ]; then
-		if [ $DRY == "y" ]; then
+	if [[ -e "$backup_path" ]]; then
+		if [[ $DRY == "y" ]]; then
 			log $LOG_NORMAL "[DRY] Would remove existing backup: $backup_path"
-		elif [ "$FORCE" == "y" ]; then
+		elif [[ "$FORCE" == "y" ]]; then
 			log $LOG_VERBOSE "[INFO] Removing existing backup: $backup_path"
 			rm -rf "$backup_path"
-		elif [ "$FORCE" == "n" ]; then
+		elif [[ "$FORCE" == "n" ]]; then
 			log $LOG_NORMAL "[INFO] Backup target already exists: $backup_path. Exiting..."
 			exit 0
 		else
@@ -317,11 +317,11 @@ run() {
 		fi
 	fi
 
-	if [ $DRY == "y" ]; then
+	if [[ $DRY == "y" ]]; then
 		log $LOG_NORMAL "[DRY] Would create backup: $backup_path"
 	else
 		# create the backup
-		if [ -d "$SOURCE" ]; then
+		if [[ -d "$SOURCE" ]]; then
 			cp -r "$SOURCE" "$backup_path"
 		else
 			cp "$SOURCE" "$backup_path"

--- a/sh/cln.sh
+++ b/sh/cln.sh
@@ -13,24 +13,24 @@ set -uo pipefail
 
 IFS=$'\n\t'
 
-VERSION="v2.1.31"
+version="v2.1.31"
 app=${0##*/}
 
 # Log levels
-#LOG_SILENT=0
-LOG_QUIET=1
-LOG_NORMAL=2
-LOG_VERBOSE=3
+#log_silent=0
+log_quiet=1
+log_normal=2
+log_verbose=3
 
 # arguments and options
-DRY="n"
-RECURSE="n"
-RECURSE_DEPTH=""
-FORCE="ask"
-LOG="2"
+dry="n"
+recurse="n"
+recurse_depth=""
+force="ask"
+log="2"
 
 # Paths to process
-PATHS=()
+paths=()
 
 usage() {
 	cat <<EOF
@@ -80,21 +80,21 @@ EOF
 }
 
 version() {
-	echo "$app version $VERSION"
+	echo "$app version $version"
 }
 
 check_version() {
-	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Current version: $version"
 	echo "[INFO] Checking for updates..."
 
 	local remote_version
-	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/version)"
 
 	# strip leading and trailing whitespace
 	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
-	if [[ "$remote_version" != "$VERSION" ]]; then
+	if [[ "$remote_version" != "$version" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -111,22 +111,22 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if ((LOG >= LOG_QUIET)); then
+			if ((log >= log_quiet)); then
 				echo "$message"
 			fi
 			;;
 		2)
-			if ((LOG >= LOG_NORMAL)); then
+			if ((log >= log_normal)); then
 				echo "$message"
 			fi
 			;;
 		3)
-			if ((LOG >= LOG_VERBOSE)); then
+			if ((log >= log_verbose)); then
 				echo "$message"
 			fi
 			;;
 		*)
-			log $LOG_QUIET "[ERROR] Invalid log level: $level" >&2
+			log $log_quiet "[ERROR] Invalid log level: $level" >&2
 			exit 1
 			;;
 	esac
@@ -171,59 +171,59 @@ parse_args() {
 				exit 0
 				;;
 			-d | --dry)
-				DRY="y"
+				dry="y"
 				shift
 				;;
 			-r | --recursive)
-				RECURSE="y"
+				recurse="y"
 				shift
 				;;
 			-n | --recurse-depth)
-				RECURSE_DEPTH="$2"
+				recurse_depth="$2"
 
 				# Validate depth is a positive integer
-				if ! [[ "$RECURSE_DEPTH" =~ ^[0-9]+$ ]]; then
-					log $LOG_QUIET "[ERROR] Invalid recursion depth: $RECURSE_DEPTH" >&2
+				if ! [[ "$recurse_depth" =~ ^[0-9]+$ ]]; then
+					log $log_quiet "[ERROR] Invalid recursion depth: $recurse_depth" >&2
 					exit 1
 				fi
 
 				shift 2
 				;;
 			-f | --force)
-				FORCE="$2"
+				force="$2"
 
-				if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
-					log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
+				if [[ ! $force =~ ^(y|n|ask)$ ]]; then
+					log $log_quiet "[ERROR] Invalid force mode: $force" >&2
 					exit 1
 				fi
 
 				shift 2
 				;;
 			-l | --log)
-				LOG="$2"
+				log="$2"
 
-				if [[ ! $LOG =~ ^[0-3]$ ]]; then
-					log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
+				if [[ ! $log =~ ^[0-3]$ ]]; then
+					log $log_quiet "[ERROR] Invalid log level: $log" >&2
 					exit 1
 				fi
 
 				shift 2
 				;;
 			-*)
-				log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
+				log $log_quiet "[ERROR] Unknown option: $1" >&2
 				usage
 				exit 1
 				;;
 			*)
-				PATHS+=("$1")
+				paths+=("$1")
 				shift
 				;;
 		esac
 	done
 
 	# If no paths are provided, default to the current directory
-	if ((${#PATHS[@]} == 0)); then
-		PATHS+=(".")
+	if ((${#paths[@]} == 0)); then
+		paths+=(".")
 	fi
 }
 
@@ -249,26 +249,26 @@ replace_special_chars() {
 
 	# If new_name is empty, skip
 	if [[ -z "$new_name" ]]; then
-		log $LOG_NORMAL "[WARN] $filename: new name is empty. Skipping..." >&2
+		log $log_normal "[WARN] $filename: new name is empty. Skipping..." >&2
 		return
 	fi
 
 	# If names are the same, skip
 	if [[ "$filename" == "$new_name" ]]; then
-		log $LOG_VERBOSE "[INFO] $filename: No special characters found. Skipping..."
+		log $log_verbose "[INFO] $filename: No special characters found. Skipping..."
 		return
 	fi
 
 	target="${filepath%/*}/$new_name"
 
-	if [[ "$DRY" == "y" ]]; then
-		log $LOG_NORMAL "[DRY] Would rename: $filename -> $new_name"
+	if [[ "$dry" == "y" ]]; then
+		log $log_normal "[dry] Would rename: $filename -> $new_name"
 		if [[ -e "$target" ]]; then
-			log $LOG_NORMAL "[DRY] Would need to overwrite: $target"
+			log $log_normal "[dry] Would need to overwrite: $target"
 		fi
 		return 0
 	else
-		log $LOG_NORMAL "[INFO] Renaming: $filename -> $new_name"
+		log $log_normal "[INFO] Renaming: $filename -> $new_name"
 	fi
 
 	# Check if target file doesn't exists
@@ -277,17 +277,17 @@ replace_special_chars() {
 		return 0
 	fi
 
-	if [[ "$FORCE" == "y" ]]; then
-		log $LOG_VERBOSE "[INFO] Overwriting: $target"
+	if [[ "$force" == "y" ]]; then
+		log $log_verbose "[INFO] Overwriting: $target"
 		rm -rf "$target"
-	elif [[ "$FORCE" == "n" ]]; then
-		log $LOG_NORMAL "[INFO] File exists. Skipping...: $filename"
+	elif [[ "$force" == "n" ]]; then
+		log $log_normal "[INFO] File exists. Skipping...: $filename"
 		return 0
 	else
 		read -p "File already exists. Overwrite? [y/N] " -n 1 -r
 		echo ""
 		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-			log $LOG_NORMAL "[INFO] Skipping $filename..."
+			log $log_normal "[INFO] Skipping $filename..."
 			return 0
 		else
 			rm -rf "$target" # Remove the existing file before renaming
@@ -304,20 +304,20 @@ process_paths() {
 
 	for path in "${paths[@]}"; do
 		if [[ ! -e "$path" ]]; then
-			log $LOG_QUIET "[ERROR] $path: No such file or directory" >&2
+			log $log_quiet "[ERROR] $path: No such file or directory" >&2
 			continue
 		fi
 
 		if [[ ! -r "$path" ]] || [[ ! -w "$path" ]]; then
-			log $LOG_QUIET "[ERROR] $path: Permission denied" >&2
+			log $log_quiet "[ERROR] $path: Permission denied" >&2
 			continue
 		fi
 
-		log $LOG_VERBOSE "[INFO] Processing directory: $path"
-		if (( RECURSE_DEPTH > 0 )); then
-			log $LOG_VERBOSE "[INFO] Recurse depth: $depth of $RECURSE_DEPTH"
+		log $log_verbose "[INFO] Processing directory: $path"
+		if (( recurse_depth > 0 )); then
+			log $log_verbose "[INFO] Recurse depth: $depth of $recurse_depth"
 		else
-			log $LOG_VERBOSE "[INFO] Recurse depth: $depth"
+			log $log_verbose "[INFO] Recurse depth: $depth"
 		fi
 
 		# Process single file
@@ -327,7 +327,7 @@ process_paths() {
 		fi
 
 		# Process all files in the directory
-		if [[ "$RECURSE" != "y" ]]; then
+		if [[ "$recurse" != "y" ]]; then
 			for file in "$path"/*; do
 				replace_special_chars "$file"
 			done
@@ -337,10 +337,10 @@ process_paths() {
 		# Don't forget to process the directory itself
 		replace_special_chars "$path"
 
-		log $LOG_VERBOSE "[INFO] Recursing into: $path"
+		log $log_verbose "[INFO] Recursing into: $path"
 
 		# Recursively process directories
-		if ((depth < RECURSE_DEPTH)); then
+		if ((depth < recurse_depth)); then
 			for file in "$path"/*; do
 				if [[ -d "$file" ]]; then
 					process_paths "$((depth + 1))" "$file"
@@ -354,7 +354,7 @@ process_paths() {
 
 main() {
 	parse_args "$@"
-	process_paths 0 "${PATHS[@]}"
+	process_paths 0 "${paths[@]}"
 }
 
 main "$@"

--- a/sh/cln.sh
+++ b/sh/cln.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 #
+# Clean up filenames by replacing special characters with underscores.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
+
 IFS=$'\n\t'
 
 VERSION="v2.1.31"
-BASENAME=$(basename "$0")
+app=${0##*/}
 
 # Log levels
 #LOG_SILENT=0
@@ -25,8 +33,8 @@ LOG="2"
 PATHS=()
 
 usage() {
-  cat <<EOF
-Usage: $(basename "$0") [directories...]
+	cat <<EOF
+Usage: $app [directories...]
 
 Replace all special characters in filenames within the specified directories.
 If no directories are provided, the script will operate in the current directory.
@@ -50,16 +58,16 @@ Options:
 
 Examples:
   Replace special characters in filenames in the current directory.
-    $BASENAME
+    $app
 
   Replace special characters in filenames within ~/Documents.
-    $BASENAME ~/Documents
+    $app ~/Documents
 
   Replace special characters in filenames within ./foo and /bar.
-    $BASENAME ./foo /bar
+    $app ./foo /bar
 
   Replace special characters in filenames recursively within ~/Documents.
-    $BASENAME -r ~/Documents
+    $app -r ~/Documents
 
 Special Character Replacement:
 - The script replaces characters that are not alphanumeric or hyphens with underscores.
@@ -72,273 +80,273 @@ EOF
 }
 
 version() {
-  echo "$BASENAME version $VERSION"
+	echo "$app version $VERSION"
 }
 
 check_version() {
-  echo "[INFO] Current version: $VERSION"
-  echo "[INFO] Checking for updates..."
+	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Checking for updates..."
 
-  local remote_version
-  remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	local remote_version
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
-  # strip leading and trailing whitespace
-  remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	# strip leading and trailing whitespace
+	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
-  # Check if the remote version is different from the local version
-  if [ "$remote_version" != "$VERSION" ]; then
-    echo "[INFO] A new version of $BASENAME ($remote_version) is available!"
-    echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
-  else
-    echo "[INFO] You are running the latest version of $BASENAME."
-  fi
+	# Check if the remote version is different from the local version
+	if [ "$remote_version" != "$VERSION" ]; then
+		echo "[INFO] A new version of $app ($remote_version) is available!"
+		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
+	else
+		echo "[INFO] You are running the latest version of $app."
+	fi
 }
 
 log() {
-  local level="$1"
-  local message="$2"
+	local level="$1"
+	local message="$2"
 
-  case "$level" in
-    0)
-      # Silent mode. No output
-      ;;
-    1)
-      if [ "$LOG" -ge $LOG_QUIET ]; then
-        echo "$message"
-      fi
-      ;;
-    2)
-      if [ "$LOG" -ge $LOG_NORMAL ]; then
-        echo "$message"
-      fi
-      ;;
-    3)
-      if [ "$LOG" -ge $LOG_VERBOSE ]; then
-        echo "$message"
-      fi
-      ;;
-    *)
-      echo "[ERROR] Invalid log level: $level" >&2
-      exit 1
-      ;;
-  esac
+	case "$level" in
+		0)
+			# Silent mode. No output
+			;;
+		1)
+			if [ "$LOG" -ge $LOG_QUIET ]; then
+				echo "$message"
+			fi
+			;;
+		2)
+			if [ "$LOG" -ge $LOG_NORMAL ]; then
+				echo "$message"
+			fi
+			;;
+		3)
+			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+				echo "$message"
+			fi
+			;;
+		*)
+			echo "[ERROR] Invalid log level: $level" >&2
+			exit 1
+			;;
+	esac
 }
 
 parse_args() {
-  # Expand combined short options (e.g., -dr to -d -r)
-  expanded_args=()
-  while [[ $# -gt 0 ]]; do
-    # If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
-    if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
-      expanded_args+=("$1")
-      shift
-      continue
-    fi
+	# Expand combined short options (e.g., -dr to -d -r)
+	expanded_args=()
+	while [[ $# -gt 0 ]]; do
+		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
+		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
+			expanded_args+=("$1")
+			shift
+			continue
+		fi
 
-    # Iterate over all combined short options
-    # and expand them into separate arguments
-    # eg. -qy becomes -q -y
-    for ((i = 1; i < ${#1}; i++)); do
-      expanded_args+=("-${1:i:1}")
-    done
+		# Iterate over all combined short options
+		# and expand them into separate arguments
+		# eg. -qy becomes -q -y
+		for ((i = 1; i < ${#1}; i++)); do
+			expanded_args+=("-${1:i:1}")
+		done
 
-    shift
-  done
+		shift
+	done
 
-  # Reset positional parameters to expanded arguments
-  set -- "${expanded_args[@]}"
+	# Reset positional parameters to expanded arguments
+	set -- "${expanded_args[@]}"
 
-  while [[ $# -gt 0 ]]; do
-    case $1 in
-      -h | --help)
-        usage
-        exit 0
-        ;;
-      -v | --version)
-        version
-        exit 0
-        ;;
-      -c | --check-version)
-        check_version
-        exit 0
-        ;;
-      -d | --dry)
-        DRY="y"
-        shift
-        ;;
-      -r | --recursive)
-        RECURSE="y"
-        shift
-        ;;
-      -n | --recurse-depth)
-        RECURSE_DEPTH="$2"
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-v | --version)
+				version
+				exit 0
+				;;
+			-c | --check-version)
+				check_version
+				exit 0
+				;;
+			-d | --dry)
+				DRY="y"
+				shift
+				;;
+			-r | --recursive)
+				RECURSE="y"
+				shift
+				;;
+			-n | --recurse-depth)
+				RECURSE_DEPTH="$2"
 
-        # Validate depth is a positive integer
-        if ! [[ "$RECURSE_DEPTH" =~ ^[0-9]+$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid recursion depth: $RECURSE_DEPTH" >&2
-          exit 1
-        fi
+				# Validate depth is a positive integer
+				if ! [[ "$RECURSE_DEPTH" =~ ^[0-9]+$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid recursion depth: $RECURSE_DEPTH" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -f | --force)
-        FORCE="$2"
+				shift 2
+				;;
+			-f | --force)
+				FORCE="$2"
 
-        if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
-          exit 1
-        fi
+				if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -l | --log)
-        LOG="$2"
+				shift 2
+				;;
+			-l | --log)
+				LOG="$2"
 
-        if [[ ! $LOG =~ ^[0-3]$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
-          exit 1
-        fi
+				if [[ ! $LOG =~ ^[0-3]$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -*)
-        log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
-        usage
-        exit 1
-        ;;
-      *)
-        PATHS+=("$1")
-        shift
-        ;;
-    esac
-  done
+				shift 2
+				;;
+			-*)
+				log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+			*)
+				PATHS+=("$1")
+				shift
+				;;
+		esac
+	done
 
-  # If no paths are provided, default to the current directory
-  if [ ${#PATHS[@]} -eq 0 ]; then
-    PATHS+=(".")
-  fi
+	# If no paths are provided, default to the current directory
+	if [ ${#PATHS[@]} -eq 0 ]; then
+		PATHS+=(".")
+	fi
 }
 
 replace_special_chars() {
-  local filepath="$1"
-  local filename
-  local newname
-  local target
+	local filepath="$1"
+	local filename
+	local newname
+	local target
 
-  # Extract filename without directory path
-  filename=$(basename "$filepath")
+	# Extract filename without directory path
+	filename=$(basename "$filepath")
 
-  # Replace spaces with underscore and strip non-alphanumeric characters
-  newname=$(echo "$filename" | tr ' ' '_' | tr -s '_' | tr -cd '[:alnum:]_.-')
+	# Replace spaces with underscore and strip non-alphanumeric characters
+	newname=$(echo "$filename" | tr ' ' '_' | tr -s '_' | tr -cd '[:alnum:]_.-')
 
-  # If newname is empty, skip
-  if [ -z "$newname" ]; then
-    log $LOG_NORMAL "[WARN] $filename: new name is empty. Skipping..." >&2
-    return
-  fi
+	# If newname is empty, skip
+	if [ -z "$newname" ]; then
+		log $LOG_NORMAL "[WARN] $filename: new name is empty. Skipping..." >&2
+		return
+	fi
 
-  target="$(dirname "$filepath")/$newname"
+	target="$(dirname "$filepath")/$newname"
 
-  # If names are the same, skip
-  if [ "$filename" == "$newname" ]; then
-    log $LOG_VERBOSE "[INFO] $filename: No special characters found. Skipping..."
-    return
-  fi
+	# If names are the same, skip
+	if [ "$filename" == "$newname" ]; then
+		log $LOG_VERBOSE "[INFO] $filename: No special characters found. Skipping..."
+		return
+	fi
 
-  if [ "$DRY" == "y" ]; then
-    log $LOG_NORMAL "[DRY] Would rename: $filename -> $newname"
-    if [ -e "$target" ]; then
-      log $LOG_NORMAL "[DRY] Would need to overwrite: $target"
-    fi
-    return 0
-  else
-    log $LOG_NORMAL "[INFO] Renaming: $filename -> $newname"
-  fi
+	if [ "$DRY" == "y" ]; then
+		log $LOG_NORMAL "[DRY] Would rename: $filename -> $newname"
+		if [ -e "$target" ]; then
+			log $LOG_NORMAL "[DRY] Would need to overwrite: $target"
+		fi
+		return 0
+	else
+		log $LOG_NORMAL "[INFO] Renaming: $filename -> $newname"
+	fi
 
-  # Check if target file doesn't exists
-  if ! [ -e "$target" ]; then
-    mv "$filepath" "$target"
-    return 0
-  fi
+	# Check if target file doesn't exists
+	if ! [ -e "$target" ]; then
+		mv "$filepath" "$target"
+		return 0
+	fi
 
-  if [ "$FORCE" == "y" ]; then
-    log $LOG_VERBOSE "[INFO] Overwriting: $target"
-    rm -rf "$target"
-  elif [ "$FORCE" == "n" ]; then
-    log $LOG_NORMAL "[INFO] File exists. Skipping...: $filename"
-    return 0
-  else
-    read -p "File already exists. Overwrite? [y/N] " -n 1 -r
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      log $LOG_NORMAL "[INFO] Skipping $filename..."
-      return 0
-    else
-      rm -rf "$target" # Remove the existing file before renaming
-    fi
-  fi
+	if [ "$FORCE" == "y" ]; then
+		log $LOG_VERBOSE "[INFO] Overwriting: $target"
+		rm -rf "$target"
+	elif [ "$FORCE" == "n" ]; then
+		log $LOG_NORMAL "[INFO] File exists. Skipping...: $filename"
+		return 0
+	else
+		read -p "File already exists. Overwrite? [y/N] " -n 1 -r
+		echo ""
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log $LOG_NORMAL "[INFO] Skipping $filename..."
+			return 0
+		else
+			rm -rf "$target" # Remove the existing file before renaming
+		fi
+	fi
 
-  mv "$filepath" "$target"
+	mv "$filepath" "$target"
 }
 
 process_paths() {
-  local depth=$1
-  shift
-  local paths=("$@")
+	local depth=$1
+	shift
+	local paths=("$@")
 
-  for path in "${paths[@]}"; do
-    if [ ! -e "$path" ]; then
-      log $LOG_QUIET "[ERROR] $path: No such file or directory" >&2
-      continue
-    fi
+	for path in "${paths[@]}"; do
+		if [ ! -e "$path" ]; then
+			log $LOG_QUIET "[ERROR] $path: No such file or directory" >&2
+			continue
+		fi
 
-    if [ ! -r "$path" ] || [ ! -w "$path" ]; then
-      log $LOG_QUIET "[ERROR] $path: Permission denied" >&2
-      continue
-    fi
+		if [ ! -r "$path" ] || [ ! -w "$path" ]; then
+			log $LOG_QUIET "[ERROR] $path: Permission denied" >&2
+			continue
+		fi
 
-    log $LOG_VERBOSE "[INFO] Processing directory: $path"
-    if [ "$RECURSE_DEPTH" -gt 0 ]; then
-      log $LOG_VERBOSE "[INFO] Recurse depth: $depth of $RECURSE_DEPTH"
-    else
-      log $LOG_VERBOSE "[INFO] Recurse depth: $depth"
-    fi
+		log $LOG_VERBOSE "[INFO] Processing directory: $path"
+		if [ "$RECURSE_DEPTH" -gt 0 ]; then
+			log $LOG_VERBOSE "[INFO] Recurse depth: $depth of $RECURSE_DEPTH"
+		else
+			log $LOG_VERBOSE "[INFO] Recurse depth: $depth"
+		fi
 
-    # Process single file
-    if [ -f "$path" ]; then
-      replace_special_chars "$path"
-      continue
-    fi
+		# Process single file
+		if [ -f "$path" ]; then
+			replace_special_chars "$path"
+			continue
+		fi
 
-    # Process all files in the directory
-    if [ "$RECURSE" != "y" ]; then
-      for file in "$path"/*; do
-        replace_special_chars "$file"
-      done
-      continue
-    fi
+		# Process all files in the directory
+		if [ "$RECURSE" != "y" ]; then
+			for file in "$path"/*; do
+				replace_special_chars "$file"
+			done
+			continue
+		fi
 
-    # Don't forget to process the directory itself
-    replace_special_chars "$path"
+		# Don't forget to process the directory itself
+		replace_special_chars "$path"
 
-    log $LOG_VERBOSE "[INFO] Recursing into: $path"
+		log $LOG_VERBOSE "[INFO] Recursing into: $path"
 
-    # Recursively process directories
-    if [ "$depth" -lt "$RECURSE_DEPTH" ]; then
-      for file in "$path"/*; do
-        if [ -d "$file" ]; then
-          process_paths "$((depth + 1))" "$file"
-        else
-          replace_special_chars "$file"
-        fi
-      done
-    fi
-  done
+		# Recursively process directories
+		if [ "$depth" -lt "$RECURSE_DEPTH" ]; then
+			for file in "$path"/*; do
+				if [ -d "$file" ]; then
+					process_paths "$((depth + 1))" "$file"
+				else
+					replace_special_chars "$file"
+				fi
+			done
+		fi
+	done
 }
 
 main() {
-  parse_args "$@"
-  process_paths 0 "${PATHS[@]}"
+	parse_args "$@"
+	process_paths 0 "${PATHS[@]}"
 }
 
 main "$@"

--- a/sh/cln.sh
+++ b/sh/cln.sh
@@ -94,7 +94,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -111,17 +111,17 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [ "$LOG" -ge $LOG_QUIET ]; then
+			if [[ "$LOG" -ge $LOG_QUIET ]]; then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [ "$LOG" -ge $LOG_NORMAL ]; then
+			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
 				echo "$message"
 			fi
 			;;
@@ -222,7 +222,7 @@ parse_args() {
 	done
 
 	# If no paths are provided, default to the current directory
-	if [ ${#PATHS[@]} -eq 0 ]; then
+	if [[ ${#PATHS[@]} -eq 0 ]]; then
 		PATHS+=(".")
 	fi
 }
@@ -240,7 +240,7 @@ replace_special_chars() {
 	newname=$(echo "$filename" | tr ' ' '_' | tr -s '_' | tr -cd '[:alnum:]_.-')
 
 	# If newname is empty, skip
-	if [ -z "$newname" ]; then
+	if [[ -z "$newname" ]]; then
 		log $LOG_NORMAL "[WARN] $filename: new name is empty. Skipping..." >&2
 		return
 	fi
@@ -248,14 +248,14 @@ replace_special_chars() {
 	target="$(dirname "$filepath")/$newname"
 
 	# If names are the same, skip
-	if [ "$filename" == "$newname" ]; then
+	if [[ "$filename" == "$newname" ]]; then
 		log $LOG_VERBOSE "[INFO] $filename: No special characters found. Skipping..."
 		return
 	fi
 
-	if [ "$DRY" == "y" ]; then
+	if [[ "$DRY" == "y" ]]; then
 		log $LOG_NORMAL "[DRY] Would rename: $filename -> $newname"
-		if [ -e "$target" ]; then
+		if [[ -e "$target" ]]; then
 			log $LOG_NORMAL "[DRY] Would need to overwrite: $target"
 		fi
 		return 0
@@ -264,15 +264,15 @@ replace_special_chars() {
 	fi
 
 	# Check if target file doesn't exists
-	if ! [ -e "$target" ]; then
+	if ! [[ -e "$target" ]]; then
 		mv "$filepath" "$target"
 		return 0
 	fi
 
-	if [ "$FORCE" == "y" ]; then
+	if [[ "$FORCE" == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Overwriting: $target"
 		rm -rf "$target"
-	elif [ "$FORCE" == "n" ]; then
+	elif [[ "$FORCE" == "n" ]]; then
 		log $LOG_NORMAL "[INFO] File exists. Skipping...: $filename"
 		return 0
 	else
@@ -295,31 +295,31 @@ process_paths() {
 	local paths=("$@")
 
 	for path in "${paths[@]}"; do
-		if [ ! -e "$path" ]; then
+		if [[ ! -e "$path" ]]; then
 			log $LOG_QUIET "[ERROR] $path: No such file or directory" >&2
 			continue
 		fi
 
-		if [ ! -r "$path" ] || [ ! -w "$path" ]; then
+		if [[ ! -r "$path" ] || [ ! -w "$path" ]]; then
 			log $LOG_QUIET "[ERROR] $path: Permission denied" >&2
 			continue
 		fi
 
 		log $LOG_VERBOSE "[INFO] Processing directory: $path"
-		if [ "$RECURSE_DEPTH" -gt 0 ]; then
+		if [[ "$RECURSE_DEPTH" -gt 0 ]]; then
 			log $LOG_VERBOSE "[INFO] Recurse depth: $depth of $RECURSE_DEPTH"
 		else
 			log $LOG_VERBOSE "[INFO] Recurse depth: $depth"
 		fi
 
 		# Process single file
-		if [ -f "$path" ]; then
+		if [[ -f "$path" ]]; then
 			replace_special_chars "$path"
 			continue
 		fi
 
 		# Process all files in the directory
-		if [ "$RECURSE" != "y" ]; then
+		if [[ "$RECURSE" != "y" ]]; then
 			for file in "$path"/*; do
 				replace_special_chars "$file"
 			done
@@ -332,9 +332,9 @@ process_paths() {
 		log $LOG_VERBOSE "[INFO] Recursing into: $path"
 
 		# Recursively process directories
-		if [ "$depth" -lt "$RECURSE_DEPTH" ]; then
+		if [[ "$depth" -lt "$RECURSE_DEPTH" ]]; then
 			for file in "$path"/*; do
-				if [ -d "$file" ]; then
+				if [[ -d "$file" ]]; then
 					process_paths "$((depth + 1))" "$file"
 				else
 					replace_special_chars "$file"

--- a/sh/cln.sh
+++ b/sh/cln.sh
@@ -228,8 +228,8 @@ parse_args() {
 }
 
 replace_special_chars() {
-	local filepath="$1"
 	local filename new_name target
+	local filepath="$1"
 
 	# Extract filename without directory path
 	filename=${filepath##*/}
@@ -314,7 +314,7 @@ process_paths() {
 		fi
 
 		log $LOG_VERBOSE "[INFO] Processing directory: $path"
-		if [[ "$RECURSE_DEPTH" -gt 0 ]]; then
+		if (( RECURSE_DEPTH > 0 )); then
 			log $LOG_VERBOSE "[INFO] Recurse depth: $depth of $RECURSE_DEPTH"
 		else
 			log $LOG_VERBOSE "[INFO] Recurse depth: $depth"

--- a/sh/copy.sh
+++ b/sh/copy.sh
@@ -11,7 +11,7 @@
 
 set -uo pipefail
 
-VERSION="v2.1.30"
+version="v2.1.30"
 app=${0##*/}
 
 usage() {
@@ -40,21 +40,21 @@ EOF
 }
 
 version() {
-	echo "$app version $VERSION"
+	echo "$app version $version"
 }
 
 check_version() {
-	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Current version: $version"
 	echo "[INFO] Checking for updates..."
 
 	local remote_version
-	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/version)"
 
 	# strip leading and trailing whitespace
 	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
-	if [[ "$remote_version" != "$VERSION" ]]; then
+	if [[ "$remote_version" != "$version" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else

--- a/sh/copy.sh
+++ b/sh/copy.sh
@@ -51,7 +51,7 @@ check_version() {
 	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
 	# strip leading and trailing whitespace
-	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
 	if [[ "$remote_version" != "$VERSION" ]]; then
@@ -63,7 +63,7 @@ check_version() {
 }
 
 parse_args() {
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case $1 in
 			-h | --help)
 				usage

--- a/sh/copy.sh
+++ b/sh/copy.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 #
+# Copy shell output to the clipboard.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 VERSION="v2.1.30"
+app=${0##*/}
 
 usage() {
-  cat <<EOF
-Usage: $(basename "$0") [options]
+	cat <<EOF
+Usage: $app [options]
 
 Copies shell output to the clipboard.
 
@@ -27,79 +35,79 @@ Dependencies:
 
 Examples:
   Echo a message and copy it to the clipboard:
-    echo "Hello, world!" | $(basename "$0")
+    echo "Hello, world!" | $app
 EOF
 }
 
 version() {
-  echo "$(basename "$0") version $VERSION"
+	echo "$app version $VERSION"
 }
 
 check_version() {
-  echo "[INFO] Current version: $VERSION"
-  echo "[INFO] Checking for updates..."
+	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Checking for updates..."
 
-  local remote_version
-  remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	local remote_version
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
-  # strip leading and trailing whitespace
-  remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	# strip leading and trailing whitespace
+	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
-  # Check if the remote version is different from the local version
-  if [ "$remote_version" != "$VERSION" ]; then
-    echo "[INFO] A new version of $(basename "$0") ($remote_version) is available!"
-    echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
-  else
-    echo "[INFO] You are running the latest version of $(basename "$0")."
-  fi
+	# Check if the remote version is different from the local version
+	if [ "$remote_version" != "$VERSION" ]; then
+		echo "[INFO] A new version of $app ($remote_version) is available!"
+		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
+	else
+		echo "[INFO] You are running the latest version of $app."
+	fi
 }
 
 parse_args() {
-  while [[ $# -gt 0 ]]; do
-    case $1 in
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    -v | --version)
-      version
-      exit 0
-      ;;
-    -c | --check-version)
-      check_version
-      exit 0
-      ;;
-    *)
-      echo "[ERROR] Unknown option: $1" >&2
-      usage
-      exit 1
-      ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-v | --version)
+				version
+				exit 0
+				;;
+			-c | --check-version)
+				check_version
+				exit 0
+				;;
+			*)
+				echo "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+		esac
+	done
 }
 
 parse_args "$@"
 
 # Determine if user is running Wayland or Xorg
 if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
-  # Check if wl-copy is installed
-  if ! command -v wl-copy >/dev/null; then
-    echo "[ERROR] wl-copy is not installed" >&2
-    exit 1
-  fi
+	# Check if wl-copy is installed
+	if ! command -v wl-copy >/dev/null; then
+		echo "[ERROR] wl-copy is not installed" >&2
+		exit 1
+	fi
 
-  # Use wl-copy to copy shell output to clipboard
-  wl-copy
+	# Use wl-copy to copy shell output to clipboard
+	wl-copy
 elif [ "$XDG_SESSION_TYPE" = "x11" ]; then
-  # Check if xclip is installed
-  if ! command -v xclip >/dev/null; then
-    echo "[ERROR] xclip is not installed" >&2
-    exit 1
-  fi
+	# Check if xclip is installed
+	if ! command -v xclip >/dev/null; then
+		echo "[ERROR] xclip is not installed" >&2
+		exit 1
+	fi
 
-  # Use xclip to copy shell output to clipboard
-  xclip -selection clipboard
+	# Use xclip to copy shell output to clipboard
+	xclip -selection clipboard
 else
-  echo "[ERROR] Unknown session type: $XDG_SESSION_TYPE" >&2
-  exit 1
+	echo "[ERROR] Unknown session type: $XDG_SESSION_TYPE" >&2
+	exit 1
 fi

--- a/sh/copy.sh
+++ b/sh/copy.sh
@@ -54,7 +54,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -89,7 +89,7 @@ parse_args() {
 parse_args "$@"
 
 # Determine if user is running Wayland or Xorg
-if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+if [[ "$XDG_SESSION_TYPE" = "wayland" ]]; then
 	# Check if wl-copy is installed
 	if ! command -v wl-copy >/dev/null; then
 		echo "[ERROR] wl-copy is not installed" >&2
@@ -98,7 +98,7 @@ if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 
 	# Use wl-copy to copy shell output to clipboard
 	wl-copy
-elif [ "$XDG_SESSION_TYPE" = "x11" ]; then
+elif [[ "$XDG_SESSION_TYPE" = "x11" ]]; then
 	# Check if xclip is installed
 	if ! command -v xclip >/dev/null; then
 		echo "[ERROR] xclip is not installed" >&2

--- a/sh/copy.sh
+++ b/sh/copy.sh
@@ -20,22 +20,34 @@ Usage: $app [options]
 
 Copies shell output to the clipboard.
 
-Options:
-  -h, --help              Show this help message and exit.
-  -v, --version           Show the version of this script and exit.
-  -c, --check-version     Checks the version of this script against the remote repo version and prints a message on how to update.
+Options
+-h, --help
+	Show this help message and exit.
 
-Behavior:
-- If running under Wayland, the script uses wl-copy to copy the output to the clipboard.
-- If running under Xorg, the script uses xclip to copy the output to the clipboard.
+-v, --version
+	Show the version of this script and exit.
 
-Dependencies:
-- wl-copy: Required for Wayland sessions.
-- xclip: Required for Xorg sessions.
+-c, --check-version
+	Checks the version of this script against the remote repo version and prints a message on how to update.
 
-Examples:
-  Echo a message and copy it to the clipboard:
-    echo "Hello, world!" | $app
+Behavior
+	- If running under Wayland, the script uses wl-copy to copy the output to the clipboard.
+	- If running under Xorg, the script uses xclip to copy the output to the clipboard.
+	- If the session type is unknown, an error is displayed.
+
+Dependencies
+	- wl-copy: Required for Wayland sessions.
+	- xclip: Required for Xorg sessions.
+
+Examples
+	Echo a message and copy it to the clipboard
+		echo "Hello, world!" | $app
+
+	Copy the output of a command to the clipboard
+		ls | $app
+
+	Read a file and copy its contents to the clipboard
+		cat file.txt | $app
 EOF
 }
 

--- a/sh/hog.sh
+++ b/sh/hog.sh
@@ -11,7 +11,7 @@
 
 set -uo pipefail
 
-VERSION="v2.1.30"
+version="v2.1.30"
 app=${0##*/}
 
 dir=""
@@ -44,21 +44,21 @@ EOF
 }
 
 version() {
-	echo "$app version $VERSION"
+	echo "$app version $version"
 }
 
 check_version() {
-	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Current version: $version"
 	echo "[INFO] Checking for updates..."
 
 	local remote_version
-	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/version)"
 
 	# strip leading and trailing whitespace
 	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
-	if [[ "$remote_version" != "$VERSION" ]]; then
+	if [[ "$remote_version" != "$version" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else

--- a/sh/hog.sh
+++ b/sh/hog.sh
@@ -98,6 +98,6 @@ parse_args() {
 parse_args "$@"
 
 # Default to current directory if no directory is specified
-${dir:=$(pwd)}
+${dir:=.}
 
 du -s --one-file-system "$dir/*" "$dir/.[A-Za-z0-9]*" | sort -rn | head

--- a/sh/hog.sh
+++ b/sh/hog.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 #
+# Display the disk usage of files and directories within the specified directory.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 VERSION="v2.1.30"
+app=${0##*/}
 
 usage() {
-  cat <<EOF
-Usage: $0 <directory>
+	cat <<EOF
+Usage: $app <directory>
 
 Displays the disk usage of files and directories within the specified directory,
 sorted by size in descending order. If no directory is specified, the current
@@ -23,8 +31,8 @@ Arguments:
   DIRECTORY           The directory to analyze. If not specified, the current directory (.) is used.
 
 Example:
-  $(basename "$0")                  # Analyze the current directory
-  $(basename "$0") /path/to/dir     # Analyze the specified directory
+  $app                  # Analyze the current directory
+  $app /path/to/dir     # Analyze the specified directory
 
 Notes:
   - The script uses 'du' to calculate disk usage and 'sort' to sort the results.
@@ -34,55 +42,55 @@ EOF
 }
 
 version() {
-  echo "$(basename "$0") version $VERSION"
+	echo "$app version $VERSION"
 }
 
 check_version() {
-  echo "[INFO] Current version: $VERSION"
-  echo "[INFO] Checking for updates..."
+	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Checking for updates..."
 
-  local remote_version
-  remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	local remote_version
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
-  # strip leading and trailing whitespace
-  remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	# strip leading and trailing whitespace
+	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
-  # Check if the remote version is different from the local version
-  if [ "$remote_version" != "$VERSION" ]; then
-    echo "[INFO] A new version of $(basename "$0") ($remote_version) is available!"
-    echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
-  else
-    echo "[INFO] You are running the latest version of $(basename "$0")."
-  fi
+	# Check if the remote version is different from the local version
+	if [ "$remote_version" != "$VERSION" ]; then
+		echo "[INFO] A new version of $app ($remote_version) is available!"
+		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
+	else
+		echo "[INFO] You are running the latest version of $app."
+	fi
 }
 
 parse_args() {
-  while [[ $# -gt 0 ]]; do
-    case $1 in
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    -v | --version)
-      version
-      exit 0
-      ;;
-    -c | --check-version)
-      check_version
-      exit 0
-      ;;
-    *)
-      if [ -z "$dir" ] && [ -d "$1" ]; then
-        dir="$1"
-      else
-        echo "[ERROR] Unknown option: $1" >&2
-        usage
-        exit 1
-      fi
-      shift
-      ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-v | --version)
+				version
+				exit 0
+				;;
+			-c | --check-version)
+				check_version
+				exit 0
+				;;
+			*)
+				if [ -z "$dir" ] && [ -d "$1" ]; then
+					dir="$1"
+				else
+					echo "[ERROR] Unknown option: $1" >&2
+					usage
+					exit 1
+				fi
+				shift
+				;;
+		esac
+	done
 }
 
 parse_args "$@"

--- a/sh/hog.sh
+++ b/sh/hog.sh
@@ -56,7 +56,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -80,7 +80,7 @@ parse_args() {
 				exit 0
 				;;
 			*)
-				if [ -z "$dir" ] && [ -d "$1" ]; then
+				if [[ -z "$dir" ] && [ -d "$1" ]]; then
 					dir="$1"
 				else
 					echo "[ERROR] Unknown option: $1" >&2

--- a/sh/hog.sh
+++ b/sh/hog.sh
@@ -14,6 +14,8 @@ set -uo pipefail
 VERSION="v2.1.30"
 app=${0##*/}
 
+dir=""
+
 usage() {
 	cat <<EOF
 Usage: $app <directory>
@@ -53,7 +55,7 @@ check_version() {
 	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
 	# strip leading and trailing whitespace
-	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
 	if [[ "$remote_version" != "$VERSION" ]]; then
@@ -65,7 +67,7 @@ check_version() {
 }
 
 parse_args() {
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case $1 in
 			-h | --help)
 				usage
@@ -80,7 +82,7 @@ parse_args() {
 				exit 0
 				;;
 			*)
-				if [[ -z "$dir" ] && [ -d "$1" ]]; then
+				if [[ -z "$dir" ]] && [[ -d "$1" ]]; then
 					dir="$1"
 				else
 					echo "[ERROR] Unknown option: $1" >&2
@@ -96,6 +98,6 @@ parse_args() {
 parse_args "$@"
 
 # Default to current directory if no directory is specified
-dir="${dir:-.}"
+${dir:=$(pwd)}
 
 du -s --one-file-system "$dir/*" "$dir/.[A-Za-z0-9]*" | sort -rn | head

--- a/sh/hog.sh
+++ b/sh/hog.sh
@@ -24,22 +24,32 @@ Displays the disk usage of files and directories within the specified directory,
 sorted by size in descending order. If no directory is specified, the current
 directory is used by default.
 
-Options:
-  -h, --help              Show this help message and exit.
-  -v, --version           Show the version of this script and exit.
-  -c, --check-version     Checks the version of this script against the remote repo version and prints a message on how to update.
+Options
+-h, --help
+	Show this help message and exit.
 
-Arguments:
-  DIRECTORY           The directory to analyze. If not specified, the current directory (.) is used.
+-v, --version
+	Show the version of this script and exit.
 
-Example:
-  $app                  # Analyze the current directory
-  $app /path/to/dir     # Analyze the specified directory
+-c, --check-version
+	Checks the version of this script against the remote repo version and prints a message on how to update.
 
-Notes:
-  - The script uses 'du' to calculate disk usage and 'sort' to sort the results.
-  - The '--one-file-system' option for 'du' ensures that only the file system
-    containing the specified directory is analyzed, ignoring mounted file systems.
+Arguments
+	directory
+		Required. The directory to analyze. If not specified, the current directory "." is used.
+
+Example
+	Analyzing the current directory
+		$app
+
+	Analyzing a specific directory
+		$app /path/to/directory
+
+Notes
+	The script uses 'du' to calculate disk usage and 'sort' to sort the results.
+
+	The '--one-file-system' option for 'du' ensures that only the file system
+	containing the specified directory is analyzed, ignoring mounted file systems.
 EOF
 }
 

--- a/sh/paste.sh
+++ b/sh/paste.sh
@@ -57,7 +57,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -92,7 +92,7 @@ parse_args() {
 parse_args "$@"
 
 # Determine if user is running Wayland or Xorg
-if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+if [[ "$XDG_SESSION_TYPE" = "wayland" ]]; then
 	# Check if wl-paste is installed
 	if ! command -v wl-paste >/dev/null; then
 		echo "[ERROR] wl-paste is not installed" >&2
@@ -101,7 +101,7 @@ if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 
 	# Paste clipboard contents to stdin
 	wl-paste
-elif [ "$XDG_SESSION_TYPE" = "x11" ]; then
+elif [[ "$XDG_SESSION_TYPE" = "x11" ]]; then
 	# Check if xclip is installed
 	if ! command -v xclip >/dev/null; then
 		echo "[ERROR] xclip is not installed" >&2

--- a/sh/paste.sh
+++ b/sh/paste.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 #
+# Paste clipboard contents to stdin.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 VERSION="v2.1.30"
+app=${0##*/}
 
 usage() {
-  cat <<EOF
-Usage: $(basename "$0") [options]
+	cat <<EOF
+Usage: $app [options]
 
 Pastes clipboard contents to stdin depending on the session type (Wayland or Xorg).
 
@@ -27,82 +35,82 @@ Dependencies:
 
 Examples:
   Paste the clipboard contents to stdin:
-    $(basename "$0")
+    $app
 
   Paste the clipboard contents to a file:
-    $(basename "$0") > output.txt
+    $app > output.txt
 EOF
 }
 
 version() {
-  echo "$(basename "$0") version $VERSION"
+	echo "$app version $VERSION"
 }
 
 check_version() {
-  echo "[INFO] Current version: $VERSION"
-  echo "[INFO] Checking for updates..."
+	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Checking for updates..."
 
-  local remote_version
-  remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	local remote_version
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
-  # strip leading and trailing whitespace
-  remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	# strip leading and trailing whitespace
+	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
-  # Check if the remote version is different from the local version
-  if [ "$remote_version" != "$VERSION" ]; then
-    echo "[INFO] A new version of $(basename "$0") ($remote_version) is available!"
-    echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
-  else
-    echo "[INFO] You are running the latest version of $(basename "$0")."
-  fi
+	# Check if the remote version is different from the local version
+	if [ "$remote_version" != "$VERSION" ]; then
+		echo "[INFO] A new version of $app ($remote_version) is available!"
+		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
+	else
+		echo "[INFO] You are running the latest version of $app."
+	fi
 }
 
 parse_args() {
-  while [[ $# -gt 0 ]]; do
-    case $1 in
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    -v | --version)
-      version
-      exit 0
-      ;;
-    -c | --check-version)
-      check_version
-      exit 0
-      ;;
-    *)
-      echo "[ERROR] Unknown option: $1" >&2
-      usage
-      exit 1
-      ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-v | --version)
+				version
+				exit 0
+				;;
+			-c | --check-version)
+				check_version
+				exit 0
+				;;
+			*)
+				echo "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+		esac
+	done
 }
 
 parse_args "$@"
 
 # Determine if user is running Wayland or Xorg
 if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
-  # Check if wl-paste is installed
-  if ! command -v wl-paste >/dev/null; then
-    echo "[ERROR] wl-paste is not installed" >&2
-    exit 1
-  fi
+	# Check if wl-paste is installed
+	if ! command -v wl-paste >/dev/null; then
+		echo "[ERROR] wl-paste is not installed" >&2
+		exit 1
+	fi
 
-  # Paste clipboard contents to stdin
-  wl-paste
+	# Paste clipboard contents to stdin
+	wl-paste
 elif [ "$XDG_SESSION_TYPE" = "x11" ]; then
-  # Check if xclip is installed
-  if ! command -v xclip >/dev/null; then
-    echo "[ERROR] xclip is not installed" >&2
-    exit 1
-  fi
+	# Check if xclip is installed
+	if ! command -v xclip >/dev/null; then
+		echo "[ERROR] xclip is not installed" >&2
+		exit 1
+	fi
 
-  # Paste clipboard contents to stdin
-  xclip -o -sel clip
+	# Paste clipboard contents to stdin
+	xclip -o -sel clip
 else
-  echo "[ERROR] Unknown session type: $XDG_SESSION_TYPE" >&2
-  exit 1
+	echo "[ERROR] Unknown session type: $XDG_SESSION_TYPE" >&2
+	exit 1
 fi

--- a/sh/paste.sh
+++ b/sh/paste.sh
@@ -11,7 +11,7 @@
 
 set -uo pipefail
 
-VERSION="v2.1.30"
+version="v2.1.30"
 app=${0##*/}
 
 usage() {
@@ -43,21 +43,21 @@ EOF
 }
 
 version() {
-	echo "$app version $VERSION"
+	echo "$app version $version"
 }
 
 check_version() {
-	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Current version: $version"
 	echo "[INFO] Checking for updates..."
 
 	local remote_version
-	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/version)"
 
 	# strip leading and trailing whitespace
 	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
-	if [[ "$remote_version" != "$VERSION" ]]; then
+	if [[ "$remote_version" != "$version" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else

--- a/sh/paste.sh
+++ b/sh/paste.sh
@@ -54,7 +54,7 @@ check_version() {
 	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
 	# strip leading and trailing whitespace
-	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
 	if [[ "$remote_version" != "$VERSION" ]]; then
@@ -66,7 +66,7 @@ check_version() {
 }
 
 parse_args() {
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case $1 in
 			-h | --help)
 				usage

--- a/sh/paste.sh
+++ b/sh/paste.sh
@@ -20,25 +20,31 @@ Usage: $app [options]
 
 Pastes clipboard contents to stdin depending on the session type (Wayland or Xorg).
 
-Options:
-  -h, --help              Show this help message and exit.
-  -v, --version           Show the version of this script and exit.
-  -c, --check-version     Checks the version of this script against the remote repo version and prints a message on how to update.
+Options
+-h, --help
+	Show this help message and exit.
 
-Behavior:
-- If running under Wayland, the script uses wl-paste to paste the clipboard contents.
-- If running under Xorg, the script uses xclip to paste the clipboard contents.
+-v, --version
+	Show the version of this script and exit.
 
-Dependencies:
-- wl-paste: Required for Wayland sessions.
-- xclip: Required for Xorg sessions.
+-c, --check-version
+	Checks the version of this script against the remote repo version and prints a message on how to update.
 
-Examples:
-  Paste the clipboard contents to stdin:
-    $app
+Behavior
+	- If running under Wayland, the script uses wl-copy to copy the output to the clipboard.
+	- If running under Xorg, the script uses xclip to copy the output to the clipboard.
+	- If the session type is unknown, an error is displayed.
 
-  Paste the clipboard contents to a file:
-    $app > output.txt
+Dependencies
+	- wl-copy: Required for Wayland sessions.
+	- xclip: Required for Xorg sessions.
+
+Examples
+	Paste the clipboard contents to stdin
+		$app
+
+	Paste the clipboard contents to a file
+		$app > output.txt
 EOF
 }
 

--- a/sh/restore.sh
+++ b/sh/restore.sh
@@ -94,7 +94,7 @@ check_version() {
 	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
 	# strip leading and trailing whitespace
-	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	remote_version="${remote_version//[[:space:]]/}"
 
 	# Check if the remote version is different from the local version
 	if [[ "$remote_version" != "$VERSION" ]]; then
@@ -114,22 +114,22 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [[ "$LOG" -ge $LOG_QUIET ]]; then
+			if ((LOG >= LOG_QUIET)); then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
+			if ((LOG >= LOG_NORMAL)); then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
+			if ((LOG >= LOG_VERBOSE)); then
 				echo "$message"
 			fi
 			;;
 		*)
-			echo "[ERROR] Invalid log level: $level" >&2
+			log $LOG_QUIET "[ERROR] Invalid log level: $level" >&2
 			exit 1
 			;;
 	esac
@@ -138,7 +138,7 @@ log() {
 arg_parse() {
 	# Expand combined short options (e.g., -qy to -q -y)
 	expanded_args=()
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
 		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
 			expanded_args+=("$1")
@@ -160,7 +160,7 @@ arg_parse() {
 	set -- "${expanded_args[@]}"
 
 	# Parse long arguments
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case "$1" in
 			-h | --help)
 				usage
@@ -219,7 +219,7 @@ arg_parse() {
 	done
 
 	# Default to current directory if backup directory not provided
-	TARGET="${TARGET:-$(pwd)}"
+	${TARGET:=$(pwd)}
 
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
@@ -291,7 +291,7 @@ run() {
 	local target_file
 
 	# Check if the file name matches the backup pattern: file.2019-01-01_00-00-00.bak
-	if [[ "$(basename "$SOURCE")" =~ ^(.*)\.[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}\.bak$ ]]; then
+	if [[ "${SOURCE##*/}" =~ ^(.*)\.[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}\.bak$ ]]; then
 		# Extract the base filename without the backup extension
 		target_file="${BASH_REMATCH[1]}"
 	else

--- a/sh/restore.sh
+++ b/sh/restore.sh
@@ -97,7 +97,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -114,17 +114,17 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [ "$LOG" -ge $LOG_QUIET ]; then
+			if [[ "$LOG" -ge $LOG_QUIET ]]; then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [ "$LOG" -ge $LOG_NORMAL ]; then
+			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
 				echo "$message"
 			fi
 			;;
@@ -204,9 +204,9 @@ arg_parse() {
 				exit 1
 				;;
 			*)
-				if [ -z "$SOURCE" ]; then
+				if [[ -z "$SOURCE" ]]; then
 					SOURCE="$1"
-				elif [ -z "$TARGET" ]; then
+				elif [[ -z "$TARGET" ]]; then
 					TARGET="$1"
 				else
 					log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
@@ -224,31 +224,31 @@ arg_parse() {
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-	if [ "$FORCE" == "y" ]; then
+	if [[ "$FORCE" == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-	elif [ "$FORCE" == "n" ]; then
+	elif [[ "$FORCE" == "n" ]]; then
 		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
 	else
 		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
 	fi
 
-	if [ $DRY == "y" ]; then
+	if [[ $DRY == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
 	fi
 }
 
 prepare_source() {
-	if [ ! -e "$SOURCE" ]; then
+	if [[ ! -e "$SOURCE" ]]; then
 		log $LOG_QUIET "[ERROR] Source not found: $SOURCE" >&2
 		exit 1
-	elif [ ! -r "$SOURCE" ]; then
+	elif [[ ! -r "$SOURCE" ]]; then
 		log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
 		exit 1
 	fi
 }
 
 prepare_target() {
-	if [ ! -e "$TARGET" ]; then
+	if [[ ! -e "$TARGET" ]]; then
 		if [[ $DRY == "y" ]]; then
 			log $LOG_NORMAL "[DRY] Would create backup directory: $TARGET"
 			return
@@ -277,10 +277,10 @@ prepare_target() {
 				}
 			fi
 		fi
-	elif [ ! -d "$TARGET" ]; then
+	elif [[ ! -d "$TARGET" ]]; then
 		log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
 		exit 1
-	elif [ ! -w "$TARGET" ]; then
+	elif [[ ! -w "$TARGET" ]]; then
 		log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
 		exit 1
 	fi
@@ -304,13 +304,13 @@ run() {
 	log $LOG_NORMAL "[INFO] To target: $target_path/$target_file"
 
 	# Ask for confirmation if target_file exists
-	if [ -e "$target_path/$target_file" ]; then
-		if [ $DRY == "y" ]; then
+	if [[ -e "$target_path/$target_file" ]]; then
+		if [[ $DRY == "y" ]]; then
 			log $LOG_NORMAL "[DRY] Would overwrite existing file: $target_path/$target_file"
-		elif [ "$FORCE" == "y" ]; then
+		elif [[ "$FORCE" == "y" ]]; then
 			log $LOG_NORMAL "[INFO] Overwriting existing file: $target_path/$target_file"
 			rm -rf "${target_path:?}/$target_file"
-		elif [ "$FORCE" == "n" ]; then
+		elif [[ "$FORCE" == "n" ]]; then
 			log $LOG_NORMAL "[INFO] File exists, exiting: $target_path/$target_file"
 			exit 0
 		else
@@ -322,7 +322,7 @@ run() {
 		fi
 	fi
 
-	if [ $DRY == "y" ]; then
+	if [[ $DRY == "y" ]]; then
 		log $LOG_NORMAL "[DRY] Would restore backup: $SOURCE -> $target_path/$target_file"
 	else
 		cp -r "$SOURCE" "$target_path/$target_file" || {

--- a/sh/restore.sh
+++ b/sh/restore.sh
@@ -219,7 +219,7 @@ arg_parse() {
 	done
 
 	# Default to current directory if backup directory not provided
-	${TARGET:=$(pwd)}
+	${TARGET:=.}
 
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
@@ -287,8 +287,8 @@ prepare_target() {
 }
 
 run() {
-	local target_path="$TARGET"
 	local target_file
+	local target_path="$TARGET"
 
 	# Check if the file name matches the backup pattern: file.2019-01-01_00-00-00.bak
 	if [[ "${SOURCE##*/}" =~ ^(.*)\.[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}\.bak$ ]]; then

--- a/sh/xtract.sh
+++ b/sh/xtract.sh
@@ -133,7 +133,7 @@ check_version() {
 	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
 	# Check if the remote version is different from the local version
-	if [ "$remote_version" != "$VERSION" ]; then
+	if [[ "$remote_version" != "$VERSION" ]]; then
 		echo "[INFO] A new version of $app ($remote_version) is available!"
 		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
 	else
@@ -150,17 +150,17 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [ "$LOG" -ge $LOG_QUIET ]; then
+			if [[ "$LOG" -ge $LOG_QUIET ]]; then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [ "$LOG" -ge $LOG_NORMAL ]; then
+			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
 				echo "$message"
 			fi
 			;;
@@ -244,9 +244,9 @@ arg_parse() {
 				exit 1
 				;;
 			*)
-				if [ -z "$SOURCE" ]; then
+				if [[ -z "$SOURCE" ]]; then
 					SOURCE="$1"
-				elif [ -z "$TARGET" ]; then
+				elif [[ -z "$TARGET" ]]; then
 					TARGET="$1"
 				else
 					log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
@@ -264,24 +264,24 @@ arg_parse() {
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-	if [ "$FORCE" == "y" ]; then
+	if [[ "$FORCE" == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-	elif [ "$FORCE" == "n" ]; then
+	elif [[ "$FORCE" == "n" ]]; then
 		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
 	else
 		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
 	fi
 
-	if [ $DRY == "y" ]; then
+	if [[ $DRY == "y" ]]; then
 		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
 	fi
 }
 
 check_source() {
-	if [ -z "$SOURCE" ]; then
+	if [[ -z "$SOURCE" ]]; then
 		log $LOG_QUIET "[ERROR] No archive provided" >&2
 		exit 1
-	elif [ ! -r "$SOURCE" ]; then
+	elif [[ ! -r "$SOURCE" ]]; then
 		log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
 		exit 1
 	elif [[ ! -f $SOURCE || -z ${archive_types[${SOURCE##*.}]:-} ]]; then
@@ -291,7 +291,7 @@ check_source() {
 }
 
 check_target() {
-	if [ ! -e "$TARGET" ]; then
+	if [[ ! -e "$TARGET" ]]; then
 		if [[ $DRY == "y" ]]; then
 			log $LOG_NORMAL "[DRY] Would create directory: $TARGET"
 			return
@@ -320,10 +320,10 @@ check_target() {
 				}
 			fi
 		fi
-	elif [ ! -d "$TARGET" ]; then
+	elif [[ ! -d "$TARGET" ]]; then
 		log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
 		exit 1
-	elif [ ! -w "$TARGET" ]; then
+	elif [[ ! -w "$TARGET" ]]; then
 		log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
 		exit 1
 	fi
@@ -336,7 +336,7 @@ extract_archive() {
 	local target_dir="$TARGET"
 
 	if [[ $DRY == "y" ]]; then
-		if [ "$LOG" == $LOG_VERBOSE ]; then
+		if [[ "$LOG" == $LOG_VERBOSE ]]; then
 			log $LOG_VERBOSE "[DRY] Would create temporary directory"
 			log $LOG_VERBOSE "[DRY] Would extract $SOURCE to temporary directory"
 			log $LOG_VERBOSE "[DRY] Would move contents from temporary directory to target directory: $target_dir"
@@ -377,7 +377,7 @@ extract_archive() {
 
 	# Check exit status of the extraction command
 	local exit_code=$?
-	if [ "$exit_code" -ne 0 ]; then
+	if [[ "$exit_code" -ne 0 ]]; then
 		log $LOG_QUIET "[ERROR] Extraction failed with exit code $exit_code" >&2
 		exit 1
 	fi
@@ -388,7 +388,7 @@ extract_archive() {
 	local target
 	target="$target_dir/$(basename "$SOURCE" ."$archive_extension")"
 
-	if [ "$(find "$temp_dir" -maxdepth 1 -type d | wc -l)" -gt 1 ]; then
+	if [[ "$(find "$temp_dir" -maxdepth 1 -type d | wc -l)" -gt 1 ]]; then
 		log $LOG_VERBOSE "[INFO] Using archive name as target directory: $target"
 		log $LOG_VERBOSE "[INFO] Moving contents to target directory"
 
@@ -418,13 +418,13 @@ run() {
 	fi
 
 	if [[ $DRY == "y" ]]; then
-		if [ $LIST == "Y" ]; then
+		if [[ $LIST == "Y" ]]; then
 			log $LOG_NORMAL "[DRY] Would list contents of $SOURCE"
 		else
 			log $LOG_NORMAL "[DRY] Would extract contents of $SOURCE"
 		fi
 	else
-		if [ $LIST == "Y" ]; then
+		if [[ $LIST == "Y" ]]; then
 			log $LOG_NORMAL "[INFO] Listing contents of $SOURCE"
 			"$dependency" "$list_flag" "$SOURCE"
 		else

--- a/sh/xtract.sh
+++ b/sh/xtract.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 #
+# Extract the contents of a compressed archive to a directory.
+#
+# Author: David Urbina (davidurbina.dev@gmail.com)
+# Date: 2022-02
+# License: MIT
+# Updated: 2024-07
+#
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 VERSION="v2.1.30"
+app=${0##*/}
 
 # Log levels
 #LOG_SILENT=0
@@ -31,23 +39,23 @@ LOG=$LOG_NORMAL
 #   3. Extract flag: The flag used with the dependency command to extract contents.
 #   4. Output flag (optional): The flag used to specify the output directory for extraction.
 declare -A archive_types=(
-  ["tar"]="tar -tf -xf -C"
-  ["tar.gz"]="tar -tzf -xzf -C"
-  ["tgz"]="tar -tzf -xzf -C"
-  ["tar.bz2"]="tar -tjf -xjf -C"
-  ["tar.xz"]="tar -tJf -xJf -C"
-  ["tar.7z"]="7z l x -o"
-  ["7z"]="7z l x -o"
-  ["zip"]="unzip -l -d"
-  ["rar"]="unrar l x"
-  # ["gz"]="gzip - -dc >"
-  # ["bz2"]="bzip2 - -dc >"
-  # ["xz"]="unxz -l -dc >"
+	["tar"]="tar -tf -xf -C"
+	["tar.gz"]="tar -tzf -xzf -C"
+	["tgz"]="tar -tzf -xzf -C"
+	["tar.bz2"]="tar -tjf -xjf -C"
+	["tar.xz"]="tar -tJf -xJf -C"
+	["tar.7z"]="7z l x -o"
+	["7z"]="7z l x -o"
+	["zip"]="unzip -l -d"
+	["rar"]="unrar l x"
+	# ["gz"]="gzip - -dc >"
+	# ["bz2"]="bzip2 - -dc >"
+	# ["xz"]="unxz -l -dc >"
 )
 
 usage() {
-  cat <<EOF
-Usage: $(basename "$0") [options] <archive> [target]
+	cat <<EOF
+Usage: $app [options] <archive> [target]
 Extracts the contents of a compressed archive to a directory.
 
 Arguments:
@@ -79,13 +87,13 @@ Behavior:
 
 Examples:
   Extract the contents of file.tar.gz to the current directory:
-    $(basename "$0") file.tar.gz
+    $app file.tar.gz
 
   Extract the contents of file.tar.gz to ~/Documents:
-    $(basename "$0") file.tar.gz ~/Documents
+    $app file.tar.gz ~/Documents
 
   List the contents of file.tar.gz:
-    $(basename "$0") -l file.tar.gz
+    $app -l file.tar.gz
 
 Supported archive types (Archive types not listed here are not supported):
   - tarball: .tar, .tar.gz, .tgz, .tar.bz2, .tar.xz, .tar.7z
@@ -111,332 +119,332 @@ EOF
 }
 
 version() {
-  echo "$(basename "$0") version $VERSION"
+	echo "$app version $VERSION"
 }
 
 check_version() {
-  echo "[INFO] Current version: $VERSION"
-  echo "[INFO] Checking for updates..."
+	echo "[INFO] Current version: $VERSION"
+	echo "[INFO] Checking for updates..."
 
-  local remote_version
-  remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
+	local remote_version
+	remote_version="$(curl -s https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION)"
 
-  # strip leading and trailing whitespace
-  remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
+	# strip leading and trailing whitespace
+	remote_version="$(echo -e "${remote_version}" | tr -d '[:space:]')"
 
-  # Check if the remote version is different from the local version
-  if [ "$remote_version" != "$VERSION" ]; then
-    echo "[INFO] A new version of $(basename "$0") ($remote_version) is available!"
-    echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
-  else
-    echo "[INFO] You are running the latest version of $(basename "$0")."
-  fi
+	# Check if the remote version is different from the local version
+	if [ "$remote_version" != "$VERSION" ]; then
+		echo "[INFO] A new version of $app ($remote_version) is available!"
+		echo "[INFO] Refer to the repo README on how to update: https://github.com/Diomeh/dsu/blob/master/README.md"
+	else
+		echo "[INFO] You are running the latest version of $app."
+	fi
 }
 
 log() {
-  local level="$1"
-  local message="$2"
+	local level="$1"
+	local message="$2"
 
-  case "$level" in
-  0)
-    # Silent mode. No output
-    ;;
-  1)
-    if [ "$LOG" -ge $LOG_QUIET ]; then
-      echo "$message"
-    fi
-    ;;
-  2)
-    if [ "$LOG" -ge $LOG_NORMAL ]; then
-      echo "$message"
-    fi
-    ;;
-  3)
-    if [ "$LOG" -ge $LOG_VERBOSE ]; then
-      echo "$message"
-    fi
-    ;;
-  *)
-    echo "[ERROR] Invalid log level: $level" >&2
-    exit 1
-    ;;
-  esac
+	case "$level" in
+		0)
+			# Silent mode. No output
+			;;
+		1)
+			if [ "$LOG" -ge $LOG_QUIET ]; then
+				echo "$message"
+			fi
+			;;
+		2)
+			if [ "$LOG" -ge $LOG_NORMAL ]; then
+				echo "$message"
+			fi
+			;;
+		3)
+			if [ "$LOG" -ge $LOG_VERBOSE ]; then
+				echo "$message"
+			fi
+			;;
+		*)
+			echo "[ERROR] Invalid log level: $level" >&2
+			exit 1
+			;;
+	esac
 }
 
 arg_parse() {
-  # Expand combined short options (e.g., -qy to -q -y)
-  expanded_args=()
-  while [[ $# -gt 0 ]]; do
-    # If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
-    if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
-      expanded_args+=("$1")
-      shift
-      continue
-    fi
+	# Expand combined short options (e.g., -qy to -q -y)
+	expanded_args=()
+	while [[ $# -gt 0 ]]; do
+		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
+		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
+			expanded_args+=("$1")
+			shift
+			continue
+		fi
 
-    # Iterate over all combined short options
-    # and expand them into separate arguments
-    # eg. -qy becomes -q -y
-    for ((i = 1; i < ${#1}; i++)); do
-      expanded_args+=("-${1:i:1}")
-    done
+		# Iterate over all combined short options
+		# and expand them into separate arguments
+		# eg. -qy becomes -q -y
+		for ((i = 1; i < ${#1}; i++)); do
+			expanded_args+=("-${1:i:1}")
+		done
 
-    shift
-  done
+		shift
+	done
 
-  # Reset positional parameters to expanded arguments
-  set -- "${expanded_args[@]}"
+	# Reset positional parameters to expanded arguments
+	set -- "${expanded_args[@]}"
 
-  # Parse long arguments
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    -v | --version)
-      version
-      exit 0
-      ;;
-    -c | --check-version)
-      check_version
-      exit 0
-      ;;
-    -l | --list)
-      LIST="y"
-      shift
-      ;;
-    -d | --dry)
-      DRY="y"
-      shift
-      ;;
-    -f | --force)
-      FORCE="$2"
+	# Parse long arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-v | --version)
+				version
+				exit 0
+				;;
+			-c | --check-version)
+				check_version
+				exit 0
+				;;
+			-l | --list)
+				LIST="y"
+				shift
+				;;
+			-d | --dry)
+				DRY="y"
+				shift
+				;;
+			-f | --force)
+				FORCE="$2"
 
-      if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
-        log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
-        exit 1
-      fi
+				if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
+					exit 1
+				fi
 
-      shift 2
-      ;;
-    -L | --log)
-      LOG="$2"
+				shift 2
+				;;
+			-L | --log)
+				LOG="$2"
 
-      if [[ ! $LOG =~ ^[0-3]$ ]]; then
-        log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
-        exit 1
-      fi
+				if [[ ! $LOG =~ ^[0-3]$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
+					exit 1
+				fi
 
-      shift 2
-      ;;
-    -*)
-      log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
-      usage
-      exit 1
-      ;;
-    *)
-      if [ -z "$SOURCE" ]; then
-        SOURCE="$1"
-      elif [ -z "$TARGET" ]; then
-        TARGET="$1"
-      else
-        log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
-        usage
-        exit 1
-      fi
-      shift
-      ;;
-    esac
-  done
+				shift 2
+				;;
+			-*)
+				log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+			*)
+				if [ -z "$SOURCE" ]; then
+					SOURCE="$1"
+				elif [ -z "$TARGET" ]; then
+					TARGET="$1"
+				else
+					log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
+					usage
+					exit 1
+				fi
+				shift
+				;;
+		esac
+	done
 
-  # Default to current directory if backup directory not provided
-  TARGET="${TARGET:-$(pwd)}"
+	# Default to current directory if backup directory not provided
+	TARGET="${TARGET:-$(pwd)}"
 
-  # Will only happen when on verbose mode
-  log $LOG_VERBOSE "[INFO] Running verbose log level"
+	# Will only happen when on verbose mode
+	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-  if [ "$FORCE" == "y" ]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-  elif [ "$FORCE" == "n" ]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
-  else
-    log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
-  fi
+	if [ "$FORCE" == "y" ]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
+	elif [ "$FORCE" == "n" ]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
+	else
+		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
+	fi
 
-  if [ $DRY == "y" ]; then
-    log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
-  fi
+	if [ $DRY == "y" ]; then
+		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
+	fi
 }
 
 check_source() {
-  if [ -z "$SOURCE" ]; then
-    log $LOG_QUIET "[ERROR] No archive provided" >&2
-    exit 1
-  elif [ ! -r "$SOURCE" ]; then
-    log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
-    exit 1
-  elif [[ ! -f $SOURCE || -z ${archive_types[${SOURCE##*.}]:-} ]]; then
-    log $LOG_QUIET "[ERROR] Not a valid archive: $SOURCE" >&2
-    exit 1
-  fi
+	if [ -z "$SOURCE" ]; then
+		log $LOG_QUIET "[ERROR] No archive provided" >&2
+		exit 1
+	elif [ ! -r "$SOURCE" ]; then
+		log $LOG_QUIET "[ERROR] Permission denied: $SOURCE" >&2
+		exit 1
+	elif [[ ! -f $SOURCE || -z ${archive_types[${SOURCE##*.}]:-} ]]; then
+		log $LOG_QUIET "[ERROR] Not a valid archive: $SOURCE" >&2
+		exit 1
+	fi
 }
 
 check_target() {
-  if [ ! -e "$TARGET" ]; then
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would create directory: $TARGET"
-      return
-    fi
+	if [ ! -e "$TARGET" ]; then
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would create directory: $TARGET"
+			return
+		fi
 
-    if [[ $FORCE == "y" ]]; then
-      log $LOG_VERBOSE "[INFO] Creating directory: $TARGET"
-      mkdir -p "$TARGET" || {
-        log $LOG_QUIET "[ERROR] Could not create directory: $TARGET" >&2
-        exit 1
-      }
-    elif [[ $FORCE == "n" ]]; then
-      log $LOG_QUIET "[ERROR] Directory does not exist, exiting: $TARGET" >&2
-      exit 1
-    else
-      read -p "[WARN] Directory does not exist. Create? [y/N] " -n 1 -r
-      echo ""
-      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        log $LOG_NORMAL "[INFO] Exiting..."
-        exit 0
-      else
-        log $LOG_VERBOSE "[INFO] Creating directory: $TARGET"
-        mkdir -p "$TARGET" || {
-          log $LOG_QUIET "[ERROR] Could not create directory: $TARGET" >&2
-          exit 1
-        }
-      fi
-    fi
-  elif [ ! -d "$TARGET" ]; then
-    log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
-    exit 1
-  elif [ ! -w "$TARGET" ]; then
-    log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
-    exit 1
-  fi
+		if [[ $FORCE == "y" ]]; then
+			log $LOG_VERBOSE "[INFO] Creating directory: $TARGET"
+			mkdir -p "$TARGET" || {
+				log $LOG_QUIET "[ERROR] Could not create directory: $TARGET" >&2
+				exit 1
+			}
+		elif [[ $FORCE == "n" ]]; then
+			log $LOG_QUIET "[ERROR] Directory does not exist, exiting: $TARGET" >&2
+			exit 1
+		else
+			read -p "[WARN] Directory does not exist. Create? [y/N] " -n 1 -r
+			echo ""
+			if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+				log $LOG_NORMAL "[INFO] Exiting..."
+				exit 0
+			else
+				log $LOG_VERBOSE "[INFO] Creating directory: $TARGET"
+				mkdir -p "$TARGET" || {
+					log $LOG_QUIET "[ERROR] Could not create directory: $TARGET" >&2
+					exit 1
+				}
+			fi
+		fi
+	elif [ ! -d "$TARGET" ]; then
+		log $LOG_QUIET "[ERROR] Not a directory: $TARGET" >&2
+		exit 1
+	elif [ ! -w "$TARGET" ]; then
+		log $LOG_QUIET "[ERROR] Permission denied: $TARGET" >&2
+		exit 1
+	fi
 }
 
 extract_archive() {
-  local dependency="$1"
-  local extract_flag="$2"
-  local target_dir_flag="$3"
-  local target_dir="$TARGET"
+	local dependency="$1"
+	local extract_flag="$2"
+	local target_dir_flag="$3"
+	local target_dir="$TARGET"
 
-  if [[ $DRY == "y" ]]; then
-    if [ "$LOG" == $LOG_VERBOSE ]; then
-      log $LOG_VERBOSE "[DRY] Would create temporary directory"
-      log $LOG_VERBOSE "[DRY] Would extract $SOURCE to temporary directory"
-      log $LOG_VERBOSE "[DRY] Would move contents from temporary directory to target directory: $target_dir"
-      log $LOG_VERBOSE "[DRY] Would remove temporary directory"
-    else
-      log $LOG_NORMAL "[DRY] Would extract $SOURCE to $target_dir..."
-    fi
+	if [[ $DRY == "y" ]]; then
+		if [ "$LOG" == $LOG_VERBOSE ]; then
+			log $LOG_VERBOSE "[DRY] Would create temporary directory"
+			log $LOG_VERBOSE "[DRY] Would extract $SOURCE to temporary directory"
+			log $LOG_VERBOSE "[DRY] Would move contents from temporary directory to target directory: $target_dir"
+			log $LOG_VERBOSE "[DRY] Would remove temporary directory"
+		else
+			log $LOG_NORMAL "[DRY] Would extract $SOURCE to $target_dir..."
+		fi
 
-    return 0
-  fi
+		return 0
+	fi
 
-  log $LOG_VERBOSE "[INFO] Creating temporary directory"
+	log $LOG_VERBOSE "[INFO] Creating temporary directory"
 
-  # Create a temporary directory to extract the contents
-  local temp_dir
-  temp_dir=$(mktemp -d) || {
-    log $LOG_QUIET "[ERROR] Could not create temporary directory" >&2
-    exit 1
-  }
+	# Create a temporary directory to extract the contents
+	local temp_dir
+	temp_dir=$(mktemp -d) || {
+		log $LOG_QUIET "[ERROR] Could not create temporary directory" >&2
+		exit 1
+	}
 
-  log $LOG_NORMAL "[INFO] Extracting $SOURCE to $target_dir..."
+	log $LOG_NORMAL "[INFO] Extracting $SOURCE to $target_dir..."
 
-  if [[ -z ${target_dir_flag:-} ]]; then
-    if [[ $dependency == "unzip" ]]; then
-      "$dependency" "$SOURCE" "$extract_flag" "$temp_dir" >/dev/null
-    else
-      "$dependency" "$extract_flag" "$SOURCE" "$temp_dir" >/dev/null
-    fi
-  else
-    if [[ $dependency == "7z" ]]; then
-      # 7z requires the output flag to be prepended to the target directory
-      # eg. 7z x file.7z -o/tmp/archive (notice no space between -o and the directory)
-      "$dependency" "$extract_flag" "$SOURCE" "$target_dir_flag""$temp_dir" >/dev/null
-    else
-      "$dependency" "$extract_flag" "$SOURCE" "$target_dir_flag" "$temp_dir" >/dev/null
-    fi
-  fi
+	if [[ -z ${target_dir_flag:-} ]]; then
+		if [[ $dependency == "unzip" ]]; then
+			"$dependency" "$SOURCE" "$extract_flag" "$temp_dir" >/dev/null
+		else
+			"$dependency" "$extract_flag" "$SOURCE" "$temp_dir" >/dev/null
+		fi
+	else
+		if [[ $dependency == "7z" ]]; then
+			# 7z requires the output flag to be prepended to the target directory
+			# eg. 7z x file.7z -o/tmp/archive (notice no space between -o and the directory)
+			"$dependency" "$extract_flag" "$SOURCE" "$target_dir_flag""$temp_dir" >/dev/null
+		else
+			"$dependency" "$extract_flag" "$SOURCE" "$target_dir_flag" "$temp_dir" >/dev/null
+		fi
+	fi
 
-  # Check exit status of the extraction command
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ]; then
-    log $LOG_QUIET "[ERROR] Extraction failed with exit code $exit_code" >&2
-    exit 1
-  fi
+	# Check exit status of the extraction command
+	local exit_code=$?
+	if [ "$exit_code" -ne 0 ]; then
+		log $LOG_QUIET "[ERROR] Extraction failed with exit code $exit_code" >&2
+		exit 1
+	fi
 
-  log $LOG_VERBOSE "[INFO] Checking contents of the extracted directory: $temp_dir"
+	log $LOG_VERBOSE "[INFO] Checking contents of the extracted directory: $temp_dir"
 
-  # Check if the contents are immediately inside a folder and move them accordingly
-  local target
-  target="$target_dir/$(basename "$SOURCE" ."$archive_extension")"
+	# Check if the contents are immediately inside a folder and move them accordingly
+	local target
+	target="$target_dir/$(basename "$SOURCE" ."$archive_extension")"
 
-  if [ "$(find "$temp_dir" -maxdepth 1 -type d | wc -l)" -gt 1 ]; then
-    log $LOG_VERBOSE "[INFO] Using archive name as target directory: $target"
-    log $LOG_VERBOSE "[INFO] Moving contents to target directory"
+	if [ "$(find "$temp_dir" -maxdepth 1 -type d | wc -l)" -gt 1 ]; then
+		log $LOG_VERBOSE "[INFO] Using archive name as target directory: $target"
+		log $LOG_VERBOSE "[INFO] Moving contents to target directory"
 
-    mkdir -p "$target"
-    mv "$temp_dir"/* "$target"
-  else
-    log $LOG_VERBOSE "[INFO] Moving contents to target directory: $target_dir"
-    mv "$temp_dir"/* "$target_dir"
-  fi
+		mkdir -p "$target"
+		mv "$temp_dir"/* "$target"
+	else
+		log $LOG_VERBOSE "[INFO] Moving contents to target directory: $target_dir"
+		mv "$temp_dir"/* "$target_dir"
+	fi
 
-  # Remove the temporary directory
-  log $LOG_VERBOSE "[INFO] Removing temporary directory"
-  rmdir "$temp_dir"
+	# Remove the temporary directory
+	log $LOG_VERBOSE "[INFO] Removing temporary directory"
+	rmdir "$temp_dir"
 
-  log $LOG_NORMAL "[INFO] Extraction complete: $target"
+	log $LOG_NORMAL "[INFO] Extraction complete: $target"
 }
 
 run() {
-  local archive_extension="${SOURCE##*.}"
-  local dependency list_flag extract_flag target_dir_flag
+	local archive_extension="${SOURCE##*.}"
+	local dependency list_flag extract_flag target_dir_flag
 
-  read -r dependency list_flag extract_flag target_dir_flag <<<"${archive_types[$archive_extension]}"
+	read -r dependency list_flag extract_flag target_dir_flag <<<"${archive_types[$archive_extension]}"
 
-  if ! command -v "$dependency" &>/dev/null; then
-    log $LOG_QUIET "[ERROR] $dependency is needed but not found." >&2
-    exit 1
-  fi
+	if ! command -v "$dependency" &>/dev/null; then
+		log $LOG_QUIET "[ERROR] $dependency is needed but not found." >&2
+		exit 1
+	fi
 
-  if [[ $DRY == "y" ]]; then
-    if [ $LIST == "Y" ]; then
-      log $LOG_NORMAL "[DRY] Would list contents of $SOURCE"
-    else
-      log $LOG_NORMAL "[DRY] Would extract contents of $SOURCE"
-    fi
-  else
-    if [ $LIST == "Y" ]; then
-      log $LOG_NORMAL "[INFO] Listing contents of $SOURCE"
-      "$dependency" "$list_flag" "$SOURCE"
-    else
-      log $LOG_NORMAL "[INFO] Initiating extraction process."
-      extract_archive "$dependency" "$extract_flag" "$target_dir_flag"
-    fi
-  fi
+	if [[ $DRY == "y" ]]; then
+		if [ $LIST == "Y" ]; then
+			log $LOG_NORMAL "[DRY] Would list contents of $SOURCE"
+		else
+			log $LOG_NORMAL "[DRY] Would extract contents of $SOURCE"
+		fi
+	else
+		if [ $LIST == "Y" ]; then
+			log $LOG_NORMAL "[INFO] Listing contents of $SOURCE"
+			"$dependency" "$list_flag" "$SOURCE"
+		else
+			log $LOG_NORMAL "[INFO] Initiating extraction process."
+			extract_archive "$dependency" "$extract_flag" "$target_dir_flag"
+		fi
+	fi
 
 }
 
 main() {
-  arg_parse "$@"
+	arg_parse "$@"
 
-  log $LOG_VERBOSE "[INFO] Checking source directory"
-  check_source
+	log $LOG_VERBOSE "[INFO] Checking source directory"
+	check_source
 
-  log $LOG_VERBOSE "[INFO] Checking target directory"
-  check_target
+	log $LOG_VERBOSE "[INFO] Checking target directory"
+	check_target
 
-  run
+	run
 }
 
 main "$@"

--- a/sh/xtract.sh
+++ b/sh/xtract.sh
@@ -259,7 +259,7 @@ arg_parse() {
 	done
 
 	# Default to current directory if backup directory not provided
-	${TARGET:=$(pwd)}
+	${TARGET:=.}
 
 	# Will only happen when on verbose mode
 	log $LOG_VERBOSE "[INFO] Running verbose log level"
@@ -330,11 +330,11 @@ check_target() {
 }
 
 extract_archive() {
+	local target name
 	local dependency="$1"
 	local extract_flag="$2"
 	local target_dir_flag="$3"
 	local target_dir="$TARGET"
-	local target name
 
 	if [[ $DRY == "y" ]]; then
 		if [[ "$LOG" == "$LOG_VERBOSE" ]]; then
@@ -412,8 +412,8 @@ extract_archive() {
 }
 
 run() {
-	local archive_extension="${SOURCE##*.}"
 	local dependency list_flag extract_flag target_dir_flag
+	local archive_extension="${SOURCE##*.}"
 
 	read -r dependency list_flag extract_flag target_dir_flag <<<"${archive_types[$archive_extension]}"
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -5,7 +5,7 @@ use version_compare::Version;
 
 impl Runnable for UpdateArgs {
     fn run(&mut self) -> Result<()> {
-        let url = "https://raw.githubusercontent.com/Diomeh/dsu/master/VERSION";
+        let url = "https://raw.githubusercontent.com/Diomeh/dsu/master/version";
 
         let response = get(url)?;
 
@@ -16,7 +16,7 @@ impl Runnable for UpdateArgs {
         let remote_version = response.text()?;
         let remote_version = remote_version.trim();
         let remote_version = &remote_version[1..]; // Remove the 'v' prefix
-        let current_version = env!("CARGO_PKG_VERSION");
+        let current_version = env!("CARGO_PKG_version");
 
         let remote_version = Version::from(remote_version).unwrap();
         let current_version = Version::from(current_version).unwrap();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,7 +3,7 @@
 # -*- mode: shell-script -*-
 
 # Path vars
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_source[0]}")/.." && pwd)"
 SRC_DIR="$ROOT_DIR/sh"
 TEST_DIR="$ROOT_DIR/tests"
 TMP_DIR="$ROOT_DIR/tmp"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,7 +9,7 @@
 #
 # -*- mode: shell-script -*-
 
-set -euo pipefail
+set -uo pipefail
 
 # Log levels
 #LOG_SILENT=0
@@ -28,8 +28,8 @@ FORCE="ask"
 SUDO_COMMAND=""
 
 usage() {
-  local name=${0##*/}
-  cat <<EOF
+	local name=${0##*/}
+	cat <<EOF
 Usage: $name [OPTIONS]
 
 Removes the installed binaries and configuration files of the Diomeh's Script Utilities.
@@ -50,265 +50,265 @@ EOF
 }
 
 log() {
-  local level="$1"
-  local message="$2"
+	local level="$1"
+	local message="$2"
 
-  case "$level" in
-    0)
-      # Silent mode. No output
-      ;;
-    1)
-      if [[ "$LOG" -ge $LOG_QUIET ]]; then
-        echo "$message"
-      fi
-      ;;
-    2)
-      if [[ "$LOG" -ge $LOG_NORMAL ]]; then
-        echo "$message"
-      fi
-      ;;
-    3)
-      if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
-        echo "$message"
-      fi
-      ;;
-    *)
-      echo "[ERROR] Invalid log level: $level" >&2
-      exit 1
-      ;;
-  esac
+	case "$level" in
+		0)
+			# Silent mode. No output
+			;;
+		1)
+			if [[ "$LOG" -ge $LOG_QUIET ]]; then
+				echo "$message"
+			fi
+			;;
+		2)
+			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
+				echo "$message"
+			fi
+			;;
+		3)
+			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
+				echo "$message"
+			fi
+			;;
+		*)
+			echo "[ERROR] Invalid log level: $level" >&2
+			exit 1
+			;;
+	esac
 }
 
 arg_parse() {
-  # Expand combined short options (e.g., -qy to -q -y)
-  expanded_args=()
-  while [[ $# -gt 0 ]]; do
-    # If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
-    if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
-      expanded_args+=("$1")
-      shift
-      continue
-    fi
+	# Expand combined short options (e.g., -qy to -q -y)
+	expanded_args=()
+	while [[ $# -gt 0 ]]; do
+		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
+		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
+			expanded_args+=("$1")
+			shift
+			continue
+		fi
 
-    # Iterate over all combined short options
-    # and expand them into separate arguments
-    # eg. -qy becomes -q -y
-    for ((i = 1; i < ${#1}; i++)); do
-      expanded_args+=("-${1:i:1}")
-    done
+		# Iterate over all combined short options
+		# and expand them into separate arguments
+		# eg. -qy becomes -q -y
+		for ((i = 1; i < ${#1}; i++)); do
+			expanded_args+=("-${1:i:1}")
+		done
 
-    shift
-  done
+		shift
+	done
 
-  # Reset positional parameters to expanded arguments
-  set -- "${expanded_args[@]}"
+	# Reset positional parameters to expanded arguments
+	set -- "${expanded_args[@]}"
 
-  # Parse long arguments
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -h | --help)
-        usage
-        exit 0
-        ;;
-      -d | --dry)
-        DRY="y"
-        shift
-        ;;
-      -f | --force)
-        FORCE="$2"
+	# Parse long arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help)
+				usage
+				exit 0
+				;;
+			-d | --dry)
+				DRY="y"
+				shift
+				;;
+			-f | --force)
+				FORCE="$2"
 
-        if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
-          exit 1
-        fi
+				if [[ ! $FORCE =~ ^(y|n|ask)$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid force mode: $FORCE" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -l | --log)
-        LOG="$2"
+				shift 2
+				;;
+			-l | --log)
+				LOG="$2"
 
-        if [[ ! $LOG =~ ^[0-3]$ ]]; then
-          log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
-          exit 1
-        fi
+				if [[ ! $LOG =~ ^[0-3]$ ]]; then
+					log $LOG_QUIET "[ERROR] Invalid log level: $LOG" >&2
+					exit 1
+				fi
 
-        shift 2
-        ;;
-      -*)
-        log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
-        usage
-        exit 1
-        ;;
-      *)
-        log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
-        usage
-        exit 1
-        ;;
-    esac
-  done
+				shift 2
+				;;
+			-*)
+				log $LOG_QUIET "[ERROR] Unknown option: $1" >&2
+				usage
+				exit 1
+				;;
+			*)
+				log $LOG_QUIET "[ERROR] Unknown argument: $1" >&2
+				usage
+				exit 1
+				;;
+		esac
+	done
 
-  # Will only happen when on verbose mode
-  log $LOG_VERBOSE "[INFO] Running verbose log level"
+	# Will only happen when on verbose mode
+	log $LOG_VERBOSE "[INFO] Running verbose log level"
 
-  if [[ "$FORCE" == "y" ]]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
-  elif [[ "$FORCE" == "n" ]]; then
-    log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
-  else
-    log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
-  fi
+	if [[ "$FORCE" == "y" ]]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'yes' for all prompts."
+	elif [[ "$FORCE" == "n" ]]; then
+		log $LOG_VERBOSE "[INFO] Running non-interactive mode. Assuming 'no' for all prompts."
+	else
+		log $LOG_VERBOSE "[INFO] Running interactive mode. Will prompt for confirmation."
+	fi
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_VERBOSE "[INFO] Running dry run mode. No changes will be made."
+	fi
 }
 
 path_needs_sudo() {
-  local path="$1"
+	local path="$1"
 
-  while true; do
-    # Safeguard, prevent infinite loop
-    if [[ -z "$path" ]]; then
-      log $LOG_QUIET "[ERROR] Provided path is not valid: $1" >&2
-      exit 1
-    fi
-    if [[ "$path" == "/" ]]; then
-      echo "y"
-      break
-    fi
+	while true; do
+		# Safeguard, prevent infinite loop
+		if [[ -z "$path" ]]; then
+			log $LOG_QUIET "[ERROR] Provided path is not valid: $1" >&2
+			exit 1
+		fi
+		if [[ "$path" == "/" ]]; then
+			echo "y"
+			break
+		fi
 
-    # if exists, check write permissions
-    if [[ -e "$path" ]]; then
-      if [[ -w "$path" ]]; then
-        echo "n"
-        break
-      else
-        echo "y"
-        break
-      fi
-    else
-      # if doesn't exist, set path to parent directory and check again
-      path=$(dirname "$path")
-      continue
-    fi
-  done
+		# if exists, check write permissions
+		if [[ -e "$path" ]]; then
+			if [[ -w "$path" ]]; then
+				echo "n"
+				break
+			else
+				echo "y"
+				break
+			fi
+		else
+			# if doesn't exist, set path to parent directory and check again
+			path=$(dirname "$path")
+			continue
+		fi
+	done
 }
 
 prompt_for_sudo() {
-  if [[ $FORCE == "y" ]]; then
-    log $LOG_VERBOSE "[INFO] Elevating permissions to continue installation."
-  elif [[ $FORCE == "n" ]]; then
-    log $LOG_NORMAL "[INFO] Elevated (sudo) permissions needed to continue installation. Exiting..."
-    exit 0
-  else
-    # Elevate permissions? Prompt the user
-    read -p "Do you want to elevate permissions to continue installation? [y/N] " -n 1 -r
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      log $LOG_NORMAL "[INFO] Aborting..."
-      exit 0
-    fi
-  fi
+	if [[ $FORCE == "y" ]]; then
+		log $LOG_VERBOSE "[INFO] Elevating permissions to continue installation."
+	elif [[ $FORCE == "n" ]]; then
+		log $LOG_NORMAL "[INFO] Elevated (sudo) permissions needed to continue installation. Exiting..."
+		exit 0
+	else
+		# Elevate permissions? Prompt the user
+		read -p "Do you want to elevate permissions to continue installation? [y/N] " -n 1 -r
+		echo ""
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log $LOG_NORMAL "[INFO] Aborting..."
+			exit 0
+		fi
+	fi
 
-  # Elevate permissions
-  sudo -v || {
-    log $LOG_QUIET "[ERROR] Failed to elevate permissions. Exiting..." >&2
-    exit 1
-  }
+	# Elevate permissions
+	sudo -v || {
+		log $LOG_QUIET "[ERROR] Failed to elevate permissions. Exiting..." >&2
+		exit 1
+	}
 }
 
 set_sudo_command() {
-  local path="$1"
-  local use_sudo
-  local status
+	local path="$1"
+	local use_sudo
+	local status
 
-  use_sudo="$(path_needs_sudo "$path")"
-  status=$?
+	use_sudo="$(path_needs_sudo "$path")"
+	status=$?
 
-  if ((status != 0)); then
-    log $LOG_QUIET "[ERROR] Could not determine if sudo is needed. Exiting..." >&2
-    exit 1
-  fi
+	if ((status != 0)); then
+		log $LOG_QUIET "[ERROR] Could not determine if sudo is needed. Exiting..." >&2
+		exit 1
+	fi
 
-  if [[ "$use_sudo" == "y" ]]; then
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would use sudo to remove binaries from $path"
-    else
-      SUDO_COMMAND="sudo"
-      prompt_for_sudo
-    fi
-  fi
+	if [[ "$use_sudo" == "y" ]]; then
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would use sudo to remove binaries from $path"
+		else
+			SUDO_COMMAND="sudo"
+			prompt_for_sudo
+		fi
+	fi
 }
 
 main() {
-  local binaries=()
-  local type=""
-  local path=""
+	local binaries=()
+	local type=""
+	local path=""
 
-  arg_parse "$@"
+	arg_parse "$@"
 
-  if [[ ! -e "$CONFIG_FILE" ]]; then
-    log $LOG_NORMAL "[INFO] Nothing to uninstall. Configuration file not found: $CONFIG_FILE"
-    exit 0
-  fi
+	if [[ ! -e "$CONFIG_FILE" ]]; then
+		log $LOG_NORMAL "[INFO] Nothing to uninstall. Configuration file not found: $CONFIG_FILE"
+		exit 0
+	fi
 
-  # Read the config file
-  while IFS= read -r line; do
-    # Skip comments and empty lines
-    [[ "$line" =~ ^#.* ]] && continue
-    [[ -z "$line" ]] && continue
+	# Read the config file
+	while IFS= read -r line; do
+		# Skip comments and empty lines
+		[[ "$line" =~ ^#.* ]] && continue
+		[[ -z "$line" ]] && continue
 
-    # Read type and path
-    if [[ "$line" =~ ^type= ]]; then
-      type="${line#*=}"
-    elif [[ "$line" =~ ^path= ]]; then
-      path="${line#*=}"
-    elif [[ "$line" =~ ^[[:space:]] ]]; then
-      binaries+=("${line//[[:space:]]/}")
-    fi
-  done <"$CONFIG_FILE"
+		# Read type and path
+		if [[ "$line" =~ ^type= ]]; then
+			type="${line#*=}"
+		elif [[ "$line" =~ ^path= ]]; then
+			path="${line#*=}"
+		elif [[ "$line" =~ ^[[:space:]] ]]; then
+			binaries+=("${line//[[:space:]]/}")
+		fi
+	done <"$CONFIG_FILE"
 
-  if [[ -z "$type" ]] || [[ -z "$path" ]]; then
-    log $LOG_QUIET "[ERROR] Invalid configuration file: $CONFIG_FILE" >&2
-    exit 1
-  fi
+	if [[ -z "$type" ]] || [[ -z "$path" ]]; then
+		log $LOG_QUIET "[ERROR] Invalid configuration file: $CONFIG_FILE" >&2
+		exit 1
+	fi
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would remove existing $type installation from $path"
-  else
-    log $LOG_NORMAL "[INFO] Removing existing $type installation from $path..."
-  fi
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would remove existing $type installation from $path"
+	else
+		log $LOG_NORMAL "[INFO] Removing existing $type installation from $path..."
+	fi
 
-  set_sudo_command "$path"
-  for binary in "${binaries[@]}"; do
-    if [[ $DRY == "y" ]]; then
-      log $LOG_NORMAL "[DRY] Would remove binary: $path/$binary"
-      continue
-    fi
+	set_sudo_command "$path"
+	for binary in "${binaries[@]}"; do
+		if [[ $DRY == "y" ]]; then
+			log $LOG_NORMAL "[DRY] Would remove binary: $path/$binary"
+			continue
+		fi
 
-    log $LOG_VERBOSE "[INFO] Removing binary: $path/$binary"
-    $SUDO_COMMAND rm -f "$path/$binary" || {
-      log $LOG_QUIET "[ERROR] Failed to remove binary: $path/$binary" >&2
-      exit 1
-    }
-  done
+		log $LOG_VERBOSE "[INFO] Removing binary: $path/$binary"
+		$SUDO_COMMAND rm -f "$path/$binary" || {
+			log $LOG_QUIET "[ERROR] Failed to remove binary: $path/$binary" >&2
+			exit 1
+		}
+	done
 
-  if [[ $DRY == "y" ]]; then
-    log $LOG_NORMAL "[DRY] Would remove configuration file: $CONFIG_FILE"
-    log $LOG_NORMAL "[DRY] Would remove log file: $LOG_FILE"
-    log $LOG_NORMAL "[DRY] Would remove configuration directory: $CONFIG_PATH"
-  else
-    log $LOG_VERBOSE "[INFO] Removing configuration file: $CONFIG_FILE"
-    rm "$CONFIG_FILE" 2>/dev/null || true
+	if [[ $DRY == "y" ]]; then
+		log $LOG_NORMAL "[DRY] Would remove configuration file: $CONFIG_FILE"
+		log $LOG_NORMAL "[DRY] Would remove log file: $LOG_FILE"
+		log $LOG_NORMAL "[DRY] Would remove configuration directory: $CONFIG_PATH"
+	else
+		log $LOG_VERBOSE "[INFO] Removing configuration file: $CONFIG_FILE"
+		rm "$CONFIG_FILE" 2>/dev/null || true
 
-    log $LOG_VERBOSE "[INFO] Removing log file: $LOG_FILE"
-    rm "$LOG_FILE" 2>/dev/null || true
+		log $LOG_VERBOSE "[INFO] Removing log file: $LOG_FILE"
+		rm "$LOG_FILE" 2>/dev/null || true
 
-    log $LOG_VERBOSE "[INFO] Removing configuration directory: $CONFIG_PATH"
-    rmdir "$CONFIG_PATH" 2>/dev/null || true
+		log $LOG_VERBOSE "[INFO] Removing configuration directory: $CONFIG_PATH"
+		rmdir "$CONFIG_PATH" 2>/dev/null || true
 
-    log $LOG_NORMAL "[INFO] Uninstallation completed successfully."
-  fi
+		log $LOG_NORMAL "[INFO] Uninstallation completed successfully."
+	fi
 }
 
 main "$@"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -58,22 +58,22 @@ log() {
 			# Silent mode. No output
 			;;
 		1)
-			if [[ "$LOG" -ge $LOG_QUIET ]]; then
+			if ((LOG >= LOG_QUIET)); then
 				echo "$message"
 			fi
 			;;
 		2)
-			if [[ "$LOG" -ge $LOG_NORMAL ]]; then
+			if ((LOG >= LOG_NORMAL)); then
 				echo "$message"
 			fi
 			;;
 		3)
-			if [[ "$LOG" -ge $LOG_VERBOSE ]]; then
+			if ((LOG >= LOG_VERBOSE)); then
 				echo "$message"
 			fi
 			;;
 		*)
-			echo "[ERROR] Invalid log level: $level" >&2
+			log $LOG_QUIET "[ERROR] Invalid log level: $level" >&2
 			exit 1
 			;;
 	esac
@@ -82,7 +82,7 @@ log() {
 arg_parse() {
 	# Expand combined short options (e.g., -qy to -q -y)
 	expanded_args=()
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		# If the argument is -- or does not start with -, or is a long argument (--dry), add it as is
 		if [[ $1 == -- || $1 != -* || ! $1 =~ ^-[^-].* ]]; then
 			expanded_args+=("$1")
@@ -104,7 +104,7 @@ arg_parse() {
 	set -- "${expanded_args[@]}"
 
 	# Parse long arguments
-	while [[ $# -gt 0 ]]; do
+	while (($# > 0)); do
 		case "$1" in
 			-h | --help)
 				usage


### PR DESCRIPTION
# Changes

- Replaced spaces with tabs for indenting
- Replaced all single bracket conditionals tests for double brackets (`[ ... ]` to `[[ ... ]]`)
- Eliminated most command calls and forks and replaced with [bash parameter expansion](https://mywiki.wooledge.org/BashGuide/Parameters#Parameter_Expansion)
- Replaced attempts to determine current working dir (i.e. `BASH_SOURCE` and `pwd`) with `.` (See [style guide](https://mywiki.wooledge.org/BashFAQ/028))
- Made all global variables lowercase
- Improved logging functionality
  - Refactored `log` function
  - Added new log levels
    - silent
    - error
    - warn
    - dry
    - info
    - verbose